### PR TITLE
Converting `write` to `write_all` for TcpStream usage

### DIFF
--- a/src/mem/periph/downrupt.rs
+++ b/src/mem/periph/downrupt.rs
@@ -22,7 +22,7 @@ fn downrupt_thread(rx: Receiver<[u8; 4]>) {
                         }
                     };
 
-                    match xa.write(&msg) {
+                    match xa.write_all(&msg) {
                         Ok(_x) => {}
                         _ => {
                             break;

--- a/src/mem/periph/dsky.rs
+++ b/src/mem/periph/dsky.rs
@@ -122,7 +122,7 @@ fn handle_steam_output(stream: &mut TcpStream, dsky_rx: &Receiver<[u8; 4]>) {
             }
         };
 
-        match stream.write(&msg) {
+        match stream.write_all(&msg) {
             Ok(_x) => {}
             _ => {
                 break;


### PR DESCRIPTION
This pertains to the conversation on #1, which will close #3