### PR TITLE
Adding TC Monitor for Reset

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -44,6 +44,11 @@ pub const _RUPT_HANDRUPT: u8 = 0xA;
 
 pub const NIGHTWATCH_TIME: u32 = 1920000000 / 11700;
 
+// Each TC/TCF is 1 cycle, so we just need to have to know how many cycles it
+// takes for 300ms and thats how many TC/TCF instructions we have to see in
+// sequence to reset.
+pub const TCMONITOR_COUNT: u32 = 15000000 / 11700;
+
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum AgcUnprogSeq {
@@ -95,11 +100,15 @@ pub struct AgcCpu {
     incr_tx: Sender<()>,
 
     nightwatch: u16,
-    nightwatch_cycles: u32
+    nightwatch_cycles: u32,
+
+    tc_count: u32,
 }
 
 impl AgcUnprogInstr for AgcCpu {
     fn handle_goj(&mut self) -> u16 {
+        debug!("Handling GOJ (Restart of AGC)");
+
         // Within Memo #340, the following is listed on what GOJAM actions should
         // be performed.
         self.write_io(5, 0);    // PYJETS
@@ -130,7 +139,15 @@ impl AgcUnprogInstr for AgcCpu {
         // memo. Again, this section is to handle the generation of signals.
         // TODO: Restart Light Generation.
 
+        // Internal RAGC stuff:
+        // Reset the NIGHT WATCHMAN, TC TRAP monitors
+        self.tc_count = 0;
+
+        // Reset the CPU by resetting to address 0x800
+        self.restart();
+
         2
+
     }
 }
 
@@ -171,7 +188,8 @@ impl AgcCpu {
             rupt: 1 << RUPT_DOWNRUPT,
 
             nightwatch: 0,
-            nightwatch_cycles: 0
+            nightwatch_cycles: 0,
+            tc_count: 0,
         };
 
         cpu.reset();
@@ -184,6 +202,18 @@ impl AgcCpu {
         self.update_pc(0x800);
         self.gint = false;
     }
+
+    fn restart(&mut self) {
+        // Initial PC value for the AGC CPU is at 0x800
+        // so set the PC value to that.
+        self.update_pc(0x800);
+        self.gint = false;
+
+        // Since it's a restart, light up the DSKY to indicate a restart
+        let io_val = self.read_io(0o163);
+        self.write_io(0o163, 0o200 | io_val);
+    }
+
 
     pub fn update_pc(&mut self, val: u16) {
         self.write(REG_PC, val);
@@ -421,6 +451,20 @@ impl AgcCpu {
     }
 
     pub fn execute(&mut self, inst: &AgcInst) -> bool {
+        // Handle TC TRAP Instruction Counting. The way this will be implemented
+        // based on the wording is to count how many continuous TC/TCF
+        // instructions we receive. If it surpasses the threshold, to cause a
+        // reset. The wording in Memo #260 Revision B goes...
+        // "Occurs if too many consecutive TC or TCF  instructions are run..."
+        match inst.mnem {
+            AgcMnem::TC | AgcMnem::TCF => {
+                self.tc_count += 1;
+            }
+            _ => {
+                self.tc_count = 0;
+            }
+        }
+
         match inst.mnem {
             AgcMnem::AD => return self.ad(&inst),
             AgcMnem::ADS => return self.ads(&inst),
@@ -531,6 +575,16 @@ impl AgcCpu {
         }
     }
 
+    fn handle_tc_trap(&mut self) {
+        if self.tc_count >= TCMONITOR_COUNT {
+            self.tc_count = 0;
+
+            // Send GOJAM unprogram to restart the AGC.
+            debug!("TC TRAP Restart. Sending GOJ");
+            self.set_unprog_seq(AgcUnprogSeq::GOJ);
+        }
+    }
+
     fn update_cycles(&mut self) {
         self.mct_counter += self.cycles as f64 * 12.0;
 
@@ -538,6 +592,7 @@ impl AgcCpu {
         debug!("TotalCyles: {:?}", self.total_cycles * 12);
 
         self.handle_nightwatch();
+        self.handle_tc_trap();
 
         let timers = self.mem.fetch_timers();
         self.rupt |= timers.pump_mcts(self.cycles, &mut self.unprog);
@@ -806,5 +861,21 @@ mod cpu_tests {
             assert_eq!(cpu.read(cpu::REG_L), *expect_l);
             assert_eq!(*val, cpu.read_dp(cpu::REG_A));
         }
+    }
+
+    /// ## WRITE_DP() Unit test - REG Address
+    ///
+    /// The following test will perform specific corner case testing of writing
+    /// a Double Precision value to a specific location in register space. The
+    /// test will verify the use of a 16-bit register
+    #[test]
+    fn cpu_test_tc_trap_reset_light() {
+        let mut cpu = init_agc();
+
+        let dur = std::time::Duration::from_secs(5);
+        std::thread::sleep(dur);
+        println!("Restarting AGC. Should indicate a RESTART light");
+        cpu.restart();
+        std::thread::sleep(dur);
     }
 }

--- a/src/mem/io.rs
+++ b/src/mem/io.rs
@@ -314,9 +314,11 @@ impl AgcIoSpace {
             // # CHANNEL 35    DNT M2; OUTPUT CHANNEL DOWNLINK 2 SOCOND OF TWO   WORDS SERIALIZATION.
             CHANNEL_CHAN34 => self.downrupt.read(channel_idx),
             CHANNEL_CHAN35 => self.downrupt.read(channel_idx),
-
+            0o163 => {
+                self.dsky.get_channel_value(channel_idx)
+            }
             _ => {
-                error!("Unknown IO Channel: {:?}", channel_idx);
+                error!("Unknown IO Channel: {:o}", channel_idx);
                 self.io_mem[channel_idx]
             }
         }
@@ -349,6 +351,9 @@ impl AgcIoSpace {
             CHANNEL_CHAN35 => {
                 //info!("DOWNRUPTB: {:o}", val & 0x7FFF);
                 self.downrupt.write(channel_idx, val & 0o77777);
+            }
+            0o163 => {
+                self.dsky.set_channel_value(channel_idx, val);
             }
             _ => {
                 self.io_mem[channel_idx] = val;

--- a/src/mem/periph/dsky.rs
+++ b/src/mem/periph/dsky.rs
@@ -248,9 +248,9 @@ impl DskyDisplay {
         match channel_idx {
             0o13 => {
                 if value & 0o01000 != 0o00000 {
-                    self.output_flags |= 0o00600;
+                    self.output_flags |= 0o00400;
                 } else {
-                    self.output_flags &= 0o77177;
+                    self.output_flags &= 0o77377;
                 }
                 self.flash_tx.send(self.output_flags).unwrap();
             }

--- a/src/mem/periph/dsky.rs
+++ b/src/mem/periph/dsky.rs
@@ -13,7 +13,6 @@ pub struct DskyDisplay {
     prog: u16,
     proceed: u16,
     output_flags: u16,
-
     keypress: Receiver<u16>,
     keypress_val: u16,
     dsky_tx: Sender<[u8; 4]>,
@@ -255,7 +254,18 @@ impl DskyDisplay {
                 }
                 self.flash_tx.send(self.output_flags).unwrap();
             }
+            0o163 => {
+                self.output_flags = value;
+                self.flash_tx.send(self.output_flags).unwrap();
+            }
             _ => {}
+        }
+    }
+
+    pub fn get_channel_value(&mut self, channel_idx: usize) -> u16 {
+        match channel_idx {
+            0o163 => { self.output_flags & 0o1771 }
+            _ => { 0o00000 }
         }
     }
 
@@ -380,6 +390,10 @@ impl super::Peripheral for DskyDisplay {
                 }
                 _ => {
                     self.keypress_val = val;
+                    if self.keypress_val == 0o22 {
+                        let io_val = self.get_channel_value(0o163);
+                        self.set_channel_value(0o163, io_val & !0o00200);
+                    }
                 }
             }
             (1 << crate::cpu::RUPT_KEY1) as u16


### PR DESCRIPTION
The merge will add the ability to monitor TC instructions and check for "Too many consecutive or infrequent TC instructions". This PR will also include resetting the AGC and lighting up the RESTART light to the DSKY. 