### PR TITLE
Converting base into a library

### DIFF
--- a/src/bin/ragc.rs
+++ b/src/bin/ragc.rs
@@ -3,11 +3,8 @@ extern crate clap;
 use crossbeam_channel::unbounded;
 use env_logger;
 
-mod cpu;
-mod disasm;
-mod instr;
-mod mem;
-mod utils;
+use ragc::{mem, cpu};
+
 
 fn fetch_config<'a>() -> clap::ArgMatches<'a> {
     let about =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+pub mod cpu;
+pub mod disasm;
+pub mod instr;
+pub mod mem;
+pub mod utils;


### PR DESCRIPTION
This PR is to lay the foundations of converting `ragc` into a library and have a supporting binary to run the emulation. This will allow for further work on extension libraries when it comes to peripheral.