### PR TITLE
RAM State on start and exit of ragc run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 debug/
 **/*.rs.bk
 Cargo.lock
+.ragcstate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,8 @@ log = "0.4"
 env_logger = "0.8.4"
 crossbeam-channel = "0.5"
 clap = "2.33.3"
+ctrlc = "3.2.0"
+
+[features]
+default = ["std"]
+std = []

--- a/src/bin/ragc.rs
+++ b/src/bin/ragc.rs
@@ -17,12 +17,7 @@ fn fetch_config<'a>() -> clap::ArgMatches<'a> {
             clap::Arg::with_name("input")
                 .required(true)
                 .help("Input Firmware File to Run"),
-        )
-        .arg(
-            clap::Arg::with_name("state")
-                .required(false)
-                .help("RAM state from prior ragc run")
-    );
+        );
     let a = c.get_matches();
     a
 }

--- a/src/bin/ragc.rs
+++ b/src/bin/ragc.rs
@@ -1,8 +1,8 @@
 extern crate clap;
 
-use crossbeam_channel::{unbounded, bounded};
-use env_logger;
+use crossbeam_channel::{bounded, unbounded};
 use ctrlc;
+use env_logger;
 use log::error;
 
 use ragc::{cpu, mem};
@@ -47,7 +47,7 @@ fn main() {
         Err(x) => {
             error!("Unable to register signal handler. {:?}.", x);
             return;
-        },
+        }
         _ => {}
     }
 

--- a/src/bin/ragc.rs
+++ b/src/bin/ragc.rs
@@ -1,7 +1,9 @@
 extern crate clap;
 
-use crossbeam_channel::unbounded;
+use crossbeam_channel::{unbounded, bounded};
 use env_logger;
+use ctrlc;
+use log::error;
 
 use ragc::{cpu, mem};
 
@@ -15,7 +17,12 @@ fn fetch_config<'a>() -> clap::ArgMatches<'a> {
             clap::Arg::with_name("input")
                 .required(true)
                 .help("Input Firmware File to Run"),
-        );
+        )
+        .arg(
+            clap::Arg::with_name("state")
+                .required(false)
+                .help("RAM state from prior ragc run")
+    );
     let a = c.get_matches();
     a
 }
@@ -29,6 +36,26 @@ fn main() {
     //    })
     //    .filter(None, LevelFilter::Debug)
     //    .init();
+
+    // Register for a ctrlc handler which will push a signal to the application.
+    // If the signal handler is pushed multiple times without closing, then force
+    // closing the application and lose any close-ups of
+    let (ctrlc_tx, ctrlc_rx) = bounded(1);
+    let res = ctrlc::set_handler(move || {
+        if ctrlc_tx.is_full() == true {
+            std::process::exit(-1);
+        }
+        let _res = ctrlc_tx.send(());
+    });
+
+    match res {
+        Err(x) => {
+            error!("Unable to register signal handler. {:?}.", x);
+            return;
+        },
+        _ => {}
+    }
+
     let matches = fetch_config();
     let filename = matches.value_of("input").unwrap();
 
@@ -41,6 +68,12 @@ fn main() {
     _cpu.reset();
     let mut last_timestamp = std::time::Instant::now();
     loop {
+        // Check to see if we received a ctrlc signal. If we have, we need to
+        // exit out of the loop and exit the application.
+        if ctrlc_rx.len() > 0 {
+            break;
+        }
+
         if last_timestamp.elapsed().as_millis() == 0 {
             std::thread::sleep(std::time::Duration::new(0, 5000000));
             continue;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -576,7 +576,7 @@ impl AgcCpu {
                     debug!("RUPTLOCK Restart. Sending GOJ");
                     self.set_unprog_seq(AgcUnprogSeq::GOJ);
                 }
-            },
+            }
             false => {
                 if self.ruptlock_count > 0 {
                     self.ruptlock_count = 0;
@@ -587,7 +587,6 @@ impl AgcCpu {
                     debug!("RUPTLOCK Restart. Sending GOJ");
                     self.set_unprog_seq(AgcUnprogSeq::GOJ);
                 }
-
             }
         }
     }

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -44,6 +44,9 @@ pub struct AgcMemoryMap {
 impl AgcMemoryMap {
     pub fn new_blank(rupt_tx: Sender<u8>, incr_rx: Receiver<()>) -> AgcMemoryMap {
         AgcMemoryMap {
+            #[cfg(feature = "std")]
+            ram: ram::AgcRam::default(),
+            #[cfg(not(feature = "std"))]
             ram: ram::AgcRam::new(),
             rom: rom::AgcRom::new(),
             edit: edit::AgcEditRegs::new(),

--- a/src/mem/ram.rs
+++ b/src/mem/ram.rs
@@ -2,6 +2,9 @@ use crate::cpu;
 use crate::mem::AgcMemType;
 use log::trace;
 
+#[cfg(feature = "std")]
+use std::ops::Drop;
+
 /* Number of Banks within a given AGC computer */
 pub const RAM_NUM_BANKS: usize = 8;
 
@@ -97,6 +100,14 @@ impl AgcMemType for AgcRam {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl Drop for AgcRam {
+    fn drop(&mut self) {
+        trace!("AgcRam: Saving RAM state to file.");
+    }
+}
+
 
 #[cfg(test)]
 mod agc_ram_tests {

--- a/src/mem/ram.rs
+++ b/src/mem/ram.rs
@@ -101,12 +101,12 @@ impl AgcMemType for AgcRam {
 #[cfg(feature = "std")]
 mod ramstd {
     const DEFAULT_SAVESTATE_FILENAME: &str = ".ragcstate";
-    use super::{AgcRam, RAM_BANK_SIZE};
+    use super::{AgcRam, RAM_BANK_SIZE, RAM_NUM_BANKS};
 
-    use std::ops::Drop;
-    use std::fs::File;
-    use std::io::prelude::{Write, Read};
     use log::{trace, warn};
+    use std::fs::File;
+    use std::io::prelude::{Read, Write};
+    use std::ops::Drop;
 
     impl Drop for AgcRam {
         fn drop(&mut self) {
@@ -125,26 +125,29 @@ mod ramstd {
             let mut ram = AgcRam::new();
             match File::open(DEFAULT_SAVESTATE_FILENAME) {
                 Ok(mut savefile) => {
-                    for bank_idx in 0..super::RAM_NUM_BANKS {
-                        let mut data: [u8; RAM_BANK_SIZE*2] = [0; RAM_BANK_SIZE*2];
-                        savefile.read_exact(&mut data).unwrap();
-                        ram.banks[bank_idx] = unsafe {
-                            std::mem::transmute::<[u8; RAM_BANK_SIZE*2], [u16; RAM_BANK_SIZE]>(data)
-                        };
+                    let mut data: [u8; RAM_BANK_SIZE * RAM_NUM_BANKS * 2] =
+                        [0; RAM_BANK_SIZE * RAM_NUM_BANKS * 2];
+                    savefile.read_exact(&mut data).unwrap();
 
-                    }
-                },
+                    ram.banks = unsafe {
+                        std::mem::transmute::<
+                            [u8; RAM_BANK_SIZE * RAM_NUM_BANKS * 2],
+                            [[u16; RAM_BANK_SIZE]; RAM_NUM_BANKS],
+                        >(data)
+                    };
+                }
                 Err(x) => {
                     trace!("Unable to open save state file: {:?}", x);
-                    warn!("Unable to open save state file for AgcRam.
-                           Starting with blank memory.");
+                    warn!(
+                        "Unable to open save state file for AgcRam.
+                           Starting with blank memory."
+                    );
                 }
             }
             ram
         }
     }
 }
-
 
 #[cfg(test)]
 mod agc_ram_tests {


### PR DESCRIPTION
This is to close #16 

The following was added in this PR:
 - Added `ctrlc` to implement a Ctrl+C implementation to cleanly stop `ragc`
 - For `std`, implemented `Drop` trait to store RAM contents when the `AgcRam` struct is being dropped.
 - Added logic into `ragc` to leverage this for `std` builds