### PR TITLE
Leveraging Heapless to move towards a `no_std` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ env_logger = "0.8.4"
 crossbeam-channel = "0.5"
 clap = "2.33.3"
 ctrlc = "3.2.0"
+heapless = "*"
 
 [features]
 default = ["std"]

--- a/src/bin/ragc.rs
+++ b/src/bin/ragc.rs
@@ -1,6 +1,6 @@
 extern crate clap;
 
-use crossbeam_channel::{bounded, unbounded};
+use crossbeam_channel::bounded;
 use ctrlc;
 use env_logger;
 use log::error;
@@ -54,7 +54,8 @@ fn main() {
     let matches = fetch_config();
     let filename = matches.value_of("input").unwrap();
 
-    let (rupt_tx, _rupt_rx) = unbounded();
+    let mut q1 = heapless::spsc::Queue::new();
+    let (rupt_tx, _rupt_rx) = q1.split();
 
     let mm = mem::AgcMemoryMap::new(&filename, rupt_tx);
     let mut _cpu = cpu::AgcCpu::new(mm);

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -95,7 +95,7 @@ pub struct AgcCpu {
     pub gint: bool,
     pub is_irupt: bool,
 
-    unprog: std::collections::VecDeque<AgcUnprogSeq>,
+    unprog: heapless::Deque<AgcUnprogSeq, 8>,
     pub rupt: u16,
 
     nightwatch: u16,
@@ -176,7 +176,7 @@ impl AgcCpu {
             ir: 0x0,
             ec_flag: false,
             idx_val: 0x0,
-            unprog: std::collections::VecDeque::new(),
+            unprog: heapless::Deque::new(),
 
             total_cycles: 0,
             cycles: 0,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,4 +1,4 @@
-use log::{debug, info, trace, warn};
+use log::{debug, info, trace, warn, error};
 
 use crate::disasm::disasm;
 use crate::instr::{AgcArith, AgcControlFlow, AgcInterrupt, AgcIo, AgcLoadStore, AgcLogic};
@@ -223,7 +223,12 @@ impl AgcCpu {
 
     pub fn set_unprog_seq(&mut self, unprog_type: AgcUnprogSeq) {
         debug!("Setting UnprogSeq: {:?}", unprog_type);
-        self.unprog.push_back(unprog_type);
+        match self.unprog.push_back(unprog_type) {
+            Err(x) => {
+                error!("Unable to push Unprogram Sequence {:?} in AgcCpu Queue", x);
+            },
+            _ => {}
+        }
     }
 
     pub fn check_editing(&mut self, k: usize) {
@@ -666,7 +671,7 @@ impl AgcCpu {
                 self.handle_rupt();
                 self.is_irupt = true;
 
-                self.unprog.push_back(AgcUnprogSeq::RUPT);
+                self.set_unprog_seq(AgcUnprogSeq::RUPT);
                 let inst_data = self.calculate_instr_data();
 
                 self.print_state();
@@ -706,7 +711,7 @@ impl AgcCpu {
                 self.handle_rupt();
                 self.is_irupt = true;
 
-                self.unprog.push_back(AgcUnprogSeq::RUPT);
+                self.set_unprog_seq(AgcUnprogSeq::RUPT);
                 let inst_data = self.calculate_instr_data();
 
                 let addr: usize = (self.read(REG_PC) & 0xFFFF) as usize;

--- a/src/instr/tests/mod.rs
+++ b/src/instr/tests/mod.rs
@@ -1,16 +1,15 @@
 use crate::cpu;
 use crate::cpu::AgcCpu;
 use crate::mem;
-use crossbeam_channel::unbounded;
+use heapless::spsc::Queue;
 
 #[allow(dead_code)]
 pub fn init_agc() -> AgcCpu {
-    let (rupt_tx, _rupt_rx) = unbounded();
+    let mut rupt_queue = Queue::new();
+    let (rupt_tx, _rupt_rx) = rupt_queue.split();
 
     let mut mm = mem::AgcMemoryMap::new_blank(rupt_tx);
     mm.enable_rom_write();
-    //let mut iospace = mem::AgcIoSpace::new(mm.clone());
-    //let mut _cpu = cpu::AgcCpu::new(mm, iospace, incr_tx);
     let mut _cpu = cpu::AgcCpu::new(mm);
 
     _cpu

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -246,6 +246,7 @@ mod agc_memory_map_tests {
     use super::*;
     use crate::cpu;
     use crossbeam_channel::unbounded;
+    use heapless::Deque;
 
     ///
     /// Support function to initialize the ROM section of the AGU to a static
@@ -381,7 +382,7 @@ mod agc_memory_map_tests {
 
         // Move enought MCTs to trigger a TIME6 DINC to occur. In this case,
         // there should not be movement in TIME6 or any DINCs
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = Deque::new();
         for _i in 0..55 {
             mm.timers.pump_mcts(1, &mut unprog);
         }
@@ -444,7 +445,7 @@ mod agc_memory_map_tests {
 
         // Move enought MCTs to trigger a TIME6 DINC to occur. In this case,
         // there should not be movement in TIME6 or any DINCs
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = Deque::new();
         let mut interrupt_flags = 0;
         for _i in 0..200 {
             interrupt_flags |= mm.timers.pump_mcts(1, &mut unprog);
@@ -497,7 +498,7 @@ mod agc_memory_map_tests {
     fn test_scalar_registers() {
         let (tx, _rx) = unbounded();
         let mut mm = AgcMemoryMap::new_blank(tx);
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = Deque::new();
 
         assert_eq!(0, mm.read_io(super::io::CHANNEL_HISCALAR), "Mismatch");
         assert_eq!(0, mm.read_io(super::io::CHANNEL_LOSCALAR), "Mismatch");

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -10,8 +10,7 @@ mod timer;
 
 pub use io::AgcIoSpace;
 
-use heapless::spsc::Producer as Sender;
-use heapless::spsc::Consumer as Receiver;
+use heapless::spsc::Producer;
 
 use log::{error, trace};
 
@@ -44,7 +43,7 @@ pub struct AgcMemoryMap {
 }
 
 impl AgcMemoryMap {
-    pub fn new_blank(rupt_tx: Sender<u8, 8>) -> AgcMemoryMap {
+    pub fn new_blank(rupt_tx: Producer<u8, 8>) -> AgcMemoryMap {
         AgcMemoryMap {
             #[cfg(feature = "std")]
             ram: ram::AgcRam::default(),
@@ -61,7 +60,7 @@ impl AgcMemoryMap {
         }
     }
 
-    pub fn new(filename: &str, rupt_tx: Sender<u8, 8>) -> AgcMemoryMap {
+    pub fn new(filename: &str, rupt_tx: Producer<u8, 8>) -> AgcMemoryMap {
         let mut mm = AgcMemoryMap::new_blank(rupt_tx);
         mm.rom.load_agcbin_file(filename);
         mm
@@ -247,7 +246,6 @@ impl AgcMemoryMap {
 mod agc_memory_map_tests {
     use super::*;
     use crate::cpu;
-    use crossbeam_channel::unbounded;
     use heapless::Deque;
 
     ///

--- a/src/mem/special.rs
+++ b/src/mem/special.rs
@@ -1,5 +1,5 @@
 use crate::mem::AgcMemType;
-use crossbeam_channel::Sender;
+use heapless::spsc::{Consumer, Producer};
 use log::{error, warn};
 
 const SG_CDUX: usize = 0o32;
@@ -49,7 +49,7 @@ pub struct AgcSpecialRegs {
 // Implementations
 // =============================================================================
 impl AgcSpecialRegs {
-    pub fn new(_rupt_tx: Sender<u8>) -> Self {
+    pub fn new(_rupt_tx: Producer<u8, 8>) -> Self {
         Self {
             cdu: (0, 0, 0),
             inlink: 0,

--- a/src/mem/special.rs
+++ b/src/mem/special.rs
@@ -1,5 +1,5 @@
 use crate::mem::AgcMemType;
-use heapless::spsc::{Consumer, Producer};
+use heapless::spsc::Producer;
 use log::{error, warn};
 
 const SG_CDUX: usize = 0o32;

--- a/src/mem/timer.rs
+++ b/src/mem/timer.rs
@@ -4,7 +4,7 @@ use crate::mem::AgcMemType;
 
 use heapless::Deque;
 
-use log::debug;
+use log::{debug, error};
 
 #[derive(Clone)]
 pub struct AgcTimers {
@@ -42,6 +42,15 @@ pub const MM_TIME3: usize = 0o26;
 pub const MM_TIME4: usize = 0o27;
 pub const MM_TIME5: usize = 0o30;
 pub const MM_TIME6: usize = 0o31;
+
+fn push_unprog_seq(unprog: &mut Deque<AgcUnprogSeq, 8>, seq: AgcUnprogSeq) {
+    match unprog.push_back(seq) {
+        Err(x) => {
+            error!("Unable to push {:?} into UnprogSeq Deque", x);
+        }
+        _ => {}
+    }
+}
 
 ///
 /// 0ms              2.5ms             5ms              7.5ms             10ms
@@ -105,20 +114,20 @@ impl AgcTimers {
             // Main timer + 5ms (Timer5)
             0 => {
                 debug!("SCALAR: TIMER5 Update");
-                unprog.push_back(AgcUnprogSeq::PINC);
+                push_unprog_seq(unprog, AgcUnprogSeq::PINC);
                 self.handle_timer5()
             }
             // Main Timer + 7.5ms (Timer4)
             8 => {
                 debug!("SCALAR: TIMER4 Update");
-                unprog.push_back(AgcUnprogSeq::PINC);
+                push_unprog_seq(unprog, AgcUnprogSeq::PINC);
                 self.handle_timer4()
             }
             // Main timer + 10ms (Timer1 / Timer3)
             16 => {
                 debug!("SCALAR: TIMER1/3 Update");
-                unprog.push_back(AgcUnprogSeq::PINC);
-                unprog.push_back(AgcUnprogSeq::PINC);
+                push_unprog_seq(unprog, AgcUnprogSeq::PINC);
+                push_unprog_seq(unprog, AgcUnprogSeq::PINC);
                 self.handle_timer1_timer3(unprog)
             }
 
@@ -142,7 +151,7 @@ impl AgcTimers {
                 } else {
                     // Otherwise, we do an ABS value decrement of TIME6 register.
                     // Per the documentation.
-                    unprog.push_back(AgcUnprogSeq::DINC);
+                    push_unprog_seq(unprog, AgcUnprogSeq::DINC);
                     if self.timer6 & 0o40000 == 0o40000 {
                         self.timer6 += 1;
                     } else {
@@ -247,7 +256,7 @@ impl AgcTimers {
     pub fn handle_timer1_timer3(&mut self, unprog: &mut Deque<AgcUnprogSeq, 8>) -> u16 {
         self.timer1 += 1;
         if self.timer1 & 0o37777 == 0o00000 {
-            unprog.push_back(AgcUnprogSeq::PINC);
+            push_unprog_seq(unprog, AgcUnprogSeq::PINC);
         }
 
         self.timer3 = (self.timer3 + 1) & 0o77777;

--- a/src/mem/timer.rs
+++ b/src/mem/timer.rs
@@ -1,10 +1,10 @@
 use crate::cpu;
 use crate::cpu::AgcUnprogSeq;
-
 use crate::mem::AgcMemType;
 
+use heapless::Deque;
+
 use log::debug;
-use std::collections::VecDeque;
 
 #[derive(Clone)]
 pub struct AgcTimers {
@@ -95,7 +95,7 @@ impl AgcTimers {
         }
     }
 
-    fn increment_scaler(&mut self, unprog: &mut VecDeque<AgcUnprogSeq>) -> u16 {
+    fn increment_scaler(&mut self, unprog: &mut Deque<AgcUnprogSeq, 8>) -> u16 {
         let mut interrupt_mask = 0;
 
         self.scaler += 1;
@@ -156,7 +156,7 @@ impl AgcTimers {
         interrupt_mask
     }
 
-    pub fn pump_mcts(&mut self, mcts: u16, unprog: &mut VecDeque<AgcUnprogSeq>) -> u16 {
+    pub fn pump_mcts(&mut self, mcts: u16, unprog: &mut Deque<AgcUnprogSeq, 8>) -> u16 {
         let mut rupt = 0;
         debug!("SCALARcounter: {:?}", self.scaler_mcts);
         self.scaler_mcts += mcts * 3;
@@ -244,7 +244,7 @@ impl AgcTimers {
         //0
     }
 
-    pub fn handle_timer1_timer3(&mut self, unprog: &mut VecDeque<AgcUnprogSeq>) -> u16 {
+    pub fn handle_timer1_timer3(&mut self, unprog: &mut Deque<AgcUnprogSeq, 8>) -> u16 {
         self.timer1 += 1;
         if self.timer1 & 0o37777 == 0o00000 {
             unprog.push_back(AgcUnprogSeq::PINC);
@@ -419,7 +419,7 @@ mod timer_modules_tests {
     ///
     fn timer_pump_test() {
         let mut timers = super::AgcTimers::new();
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = heapless::Deque::new();
 
         for time_idx in 1..=5 {
             for _i in 0..855 {
@@ -470,7 +470,7 @@ mod timer_modules_tests {
     ///
     fn test_time1_overflow_increment() {
         let mut timers = super::AgcTimers::new();
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = heapless::Deque::new();
 
         timers.write(0, super::MM_TIME1, 0o37777);
         assert_eq!(
@@ -509,7 +509,7 @@ mod timer_modules_tests {
     ///
     fn test_time_overflow(time_idx: usize, interrupt_number: u8) {
         let mut timers = super::AgcTimers::new();
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = heapless::Deque::new();
 
         timers.write(0, time_idx, 0o37777);
         assert_eq!(
@@ -579,7 +579,7 @@ mod timer_modules_tests {
     ///
     fn test_time6_enable_disable() {
         let mut timers = super::AgcTimers::new();
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = heapless::Deque::new();
 
         for _i in 1..=5 {
             for _i in 0..54 {
@@ -616,7 +616,7 @@ mod timer_modules_tests {
     ///
     fn test_time6_interrupt_positive() {
         let mut timers = super::AgcTimers::new();
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = heapless::Deque::new();
 
         timers.set_time6_enable(true);
         timers.write(0, super::MM_TIME6, 0o1);
@@ -660,7 +660,7 @@ mod timer_modules_tests {
     ///
     fn test_time6_interrupt_negative() {
         let mut timers = super::AgcTimers::new();
-        let mut unprog = std::collections::VecDeque::new();
+        let mut unprog = heapless::Deque::new();
         let mut interrupt_flags = 0;
 
         // Enable the timer and prime it with a given value to test when the


### PR DESCRIPTION
Using `heapless` to provide `channel` and `VecDeque` capabilities to `ragc` while moving towards a `no_std` implementation.