### PR TITLE
Reactor on Instruction Cycles

### DIFF
--- a/src/instr/arith.rs
+++ b/src/instr/arith.rs
@@ -77,23 +77,21 @@ mod convert_test {
 }
 
 pub trait AgcArith {
-    fn ad(&mut self, inst: &AgcInst) -> bool;
-    fn ads(&mut self, inst: &AgcInst) -> bool;
-    fn das(&mut self, inst: &AgcInst) -> bool;
-    fn aug(&mut self, inst: &AgcInst) -> bool;
-    fn mp(&mut self, inst: &AgcInst) -> bool;
+    fn ad(&mut self, inst: &AgcInst) -> u16;
+    fn ads(&mut self, inst: &AgcInst) -> u16;
+    fn das(&mut self, inst: &AgcInst) -> u16;
+    fn aug(&mut self, inst: &AgcInst) -> u16;
+    fn mp(&mut self, inst: &AgcInst) -> u16;
 
-    fn su(&mut self, inst: &AgcInst) -> bool;
-    fn msu(&mut self, inst: &AgcInst) -> bool;
-    fn incr(&mut self, inst: &AgcInst) -> bool;
-    fn dim(&mut self, inst: &AgcInst) -> bool;
-    fn dv(&mut self, inst: &AgcInst) -> bool;
+    fn su(&mut self, inst: &AgcInst) -> u16;
+    fn msu(&mut self, inst: &AgcInst) -> u16;
+    fn incr(&mut self, inst: &AgcInst) -> u16;
+    fn dim(&mut self, inst: &AgcInst) -> u16;
+    fn dv(&mut self, inst: &AgcInst) -> u16;
 }
 
 impl AgcArith for AgcCpu {
-    fn ad(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn ad(&mut self, inst: &AgcInst) -> u16 {
         let a = self.read_s16(REG_A) as u16;
         let k = self.read_s16(inst.get_kaddr()) as u16;
 
@@ -105,12 +103,10 @@ impl AgcArith for AgcCpu {
         //debug!("A: {:x} | K: {:x} = R {:x}", a, k, res);
         self.write_s16(REG_A, (res & 0xFFFF) as u16);
         self.check_editing(inst.get_kaddr());
-        true
+        2
     }
 
-    fn ads(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn ads(&mut self, inst: &AgcInst) -> u16 {
         let a = self.read_s16(REG_A) as u32;
         let k = self.read_s16(inst.get_kaddr_ram());
 
@@ -122,12 +118,10 @@ impl AgcArith for AgcCpu {
         let newval = (res & 0xFFFF) as u16;
         self.write_s16(REG_A, newval);
         self.write_s16(inst.get_kaddr_ram(), newval);
-        true
+        2
     }
 
-    fn das(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 3;
-
+    fn das(&mut self, inst: &AgcInst) -> u16 {
         let mut k = inst.get_kaddr_ram();
         if k > 0 {
             k -= 1;
@@ -169,12 +163,11 @@ impl AgcArith for AgcCpu {
 
         self.write_s16(k, res_upper);
         self.write_s16(k + 1, res_lower);
-        true
+        3
     }
 
-    fn aug(&mut self, inst: &AgcInst) -> bool {
+    fn aug(&mut self, inst: &AgcInst) -> u16 {
         let k = inst.get_kaddr_ram();
-        self.cycles = 2;
 
         match k {
             REG_A | REG_Q => {
@@ -203,7 +196,7 @@ impl AgcArith for AgcCpu {
             }
         }
 
-        true
+        2
     }
 
     ///
@@ -215,9 +208,7 @@ impl AgcArith for AgcCpu {
     /// ### Parameters
     ///  - `inst` - Agc Instruction Structure that has been disassembled
     ///
-    fn mp(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 3;
-
+    fn mp(&mut self, inst: &AgcInst) -> u16 {
         // Fetch the A and K values in preparation to multiply. Also capture the
         // sign values of each of these so we know what the result should be.
         // Get the Sign and Magnitude Bits from A
@@ -273,12 +264,10 @@ impl AgcArith for AgcCpu {
             }
         }
         self.write_dp(REG_A, res);
-        true
+        3
     }
 
-    fn incr(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn incr(&mut self, inst: &AgcInst) -> u16 {
         let k = inst.get_kaddr_ram();
         let val: u32 = self.read(k) as u32;
         trace!("INCR: {:x}: {:x}", k, val);
@@ -297,7 +286,7 @@ impl AgcArith for AgcCpu {
         };
 
         self.write(k, (kval & 0o177777) as u16);
-        false
+        2
     }
 
     ///
@@ -309,9 +298,7 @@ impl AgcArith for AgcCpu {
     /// ### Parameters
     ///  - `inst` - Agc Instruction Structure that has been disassembled
     ///
-    fn su(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn su(&mut self, inst: &AgcInst) -> u16 {
         let a = self.read_s16(REG_A);
         let kval = !self.read_s16(inst.get_kaddr_ram());
         let mut res: u32 = a as u32 + kval as u32;
@@ -320,7 +307,7 @@ impl AgcArith for AgcCpu {
         }
         self.write_s16(REG_A, (res & 0xFFFF) as u16);
         self.check_editing(inst.get_kaddr_ram());
-        false
+        2
     }
 
     ///
@@ -333,9 +320,7 @@ impl AgcArith for AgcCpu {
     /// ### Parameters
     ///  - `inst` - Agc Instruction Structure that has been disassembled
     ///
-    fn msu(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn msu(&mut self, inst: &AgcInst) -> u16 {
         let k = inst.get_kaddr_ram();
         match k {
             REG_A | REG_Q => {
@@ -363,8 +348,7 @@ impl AgcArith for AgcCpu {
         }
 
         self.check_editing(k);
-
-        false
+        2
     }
 
     ///
@@ -377,9 +361,7 @@ impl AgcArith for AgcCpu {
     /// ### Parameters
     ///  - `inst` - Agc Instruction Structure that has been disassembled
     ///
-    fn dim(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn dim(&mut self, inst: &AgcInst) -> u16 {
         let k = inst.get_kaddr_ram();
         let kval = self.read_s16(k);
         debug!("DIM: {:x}: {:x}", k, kval);
@@ -389,7 +371,7 @@ impl AgcArith for AgcCpu {
         match kval {
             // If we are +/-0, then we just nop and don't alter the K value
             // From here.
-            0o177777 | 0o00000 => false,
+            0o177777 | 0o00000 => {},
 
             // This means we are non-zero so we need to DIM the magnitude of
             // the value stored in K.
@@ -407,9 +389,10 @@ impl AgcArith for AgcCpu {
                         self.write_s16(k, kval - 1);
                     }
                 }
-                false
             }
-        }
+        };
+
+        2
     }
 
     ///
@@ -423,8 +406,7 @@ impl AgcArith for AgcCpu {
     ///   - `inst` - Instruction that was assembled to DV instruction
     ///
     ///
-    fn dv(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 6;
+    fn dv(&mut self, inst: &AgcInst) -> u16 {
         let zero_list = [0o77777, 0o00000];
 
         let divisor = self.read_s15(inst.get_kaddr_ram());
@@ -469,7 +451,7 @@ impl AgcArith for AgcCpu {
                     self.write_s15(REG_A, 0o40000);
                 }
             };
-            return true;
+            return 6;
         };
 
         // Dividend is now non-zero at this point.
@@ -484,12 +466,12 @@ impl AgcArith for AgcCpu {
                     self.write_s15(REG_A, 0o40000);
                 }
                 self.write_s15(REG_L, dividend_upper);
-                return true;
+                return 6;
             } else {
                 log::warn!("Undefined behavior!");
             }
 
-            return true;
+            return 6;
         }
 
         let dividend = convert_to_dp(dividend_upper, dividend_lower);
@@ -513,6 +495,6 @@ impl AgcArith for AgcCpu {
             }
         }
 
-        false
+        6
     }
 }

--- a/src/instr/arith.rs
+++ b/src/instr/arith.rs
@@ -43,7 +43,6 @@ fn convert_to_dp(upper: u16, lower: u16) -> u32 {
                     val |= crate::utils::s15_add(lower, 0o40000) as u32;
                     val
                 } else {
-                    log::warn!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
                     let mut val: u32 = crate::utils::s15_add(upper, 0o00001) as u32;
                     val = val << 14;
                     val |= crate::utils::s15_add(lower, 0o37777) as u32;
@@ -51,7 +50,6 @@ fn convert_to_dp(upper: u16, lower: u16) -> u32 {
                 };
 
                 if res & 0o4000000000 == 0o4000000000 {
-                    log::warn!("Using this!");
                     res += 1;
                 }
                 res & 0o3777777777
@@ -468,7 +466,7 @@ impl AgcArith for AgcCpu {
                 self.write_s15(REG_L, dividend_upper);
                 return 6;
             } else {
-                log::warn!("Undefined behavior!");
+                log::warn!("Undefined behavior for DV!");
             }
 
             return 6;

--- a/src/instr/intrpt.rs
+++ b/src/instr/intrpt.rs
@@ -2,28 +2,24 @@ use super::AgcInst;
 use crate::cpu::*;
 
 pub trait AgcInterrupt {
-    fn inhint(&mut self, inst: &AgcInst) -> bool;
-    fn relint(&mut self, inst: &AgcInst) -> bool;
-    fn edrupt(&mut self, inst: &AgcInst) -> bool;
-    fn resume(&mut self, inst: &AgcInst) -> bool;
+    fn inhint(&mut self, inst: &AgcInst) -> u16;
+    fn relint(&mut self, inst: &AgcInst) -> u16;
+    fn edrupt(&mut self, inst: &AgcInst) -> u16;
+    fn resume(&mut self, inst: &AgcInst) -> u16;
 }
 
 impl AgcInterrupt for AgcCpu {
-    fn inhint(&mut self, _inst: &AgcInst) -> bool {
+    fn inhint(&mut self, _inst: &AgcInst) -> u16 {
         self.gint = false;
-        self.cycles = 1;
-        true
+        1
     }
 
-    fn relint(&mut self, _inst: &AgcInst) -> bool {
+    fn relint(&mut self, _inst: &AgcInst) -> u16 {
         self.gint = true;
-        self.cycles = 1;
-        true
+        1
     }
 
-    fn edrupt(&mut self, _inst: &AgcInst) -> bool {
-        self.cycles = 3;
-
+    fn edrupt(&mut self, _inst: &AgcInst) -> u16 {
         // Inhibits interrupts
         self.gint = false;
 
@@ -33,12 +29,10 @@ impl AgcInterrupt for AgcCpu {
         // TODO: Takes the next instruction from address 0
         //   which sounds like IR = *Addr(0)
 
-        false
+        3
     }
 
-    fn resume(&mut self, _inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn resume(&mut self, _inst: &AgcInst) -> u16 {
         let val = self.read(REG_PC_SHADOW) - 1;
         self.write(REG_PC, val);
         self.ir = self.read(REG_IR);
@@ -48,7 +42,7 @@ impl AgcInterrupt for AgcCpu {
         self.gint = true;
         self.is_irupt = false;
 
-        false
+        2
     }
 }
 

--- a/src/instr/io.rs
+++ b/src/instr/io.rs
@@ -5,13 +5,13 @@ use crate::utils::{overflow_correction, sign_extend};
 use log::debug;
 
 pub trait AgcIo {
-    fn ror(&mut self, inst: &AgcInst) -> bool;
-    fn rand(&mut self, inst: &AgcInst) -> bool;
-    fn wor(&mut self, inst: &AgcInst) -> bool;
-    fn wand(&mut self, inst: &AgcInst) -> bool;
-    fn read_instr(&mut self, inst: &AgcInst) -> bool;
-    fn write_instr(&mut self, inst: &AgcInst) -> bool;
-    fn rxor(&mut self, inst: &AgcInst) -> bool;
+    fn ror(&mut self, inst: &AgcInst) -> u16 ;
+    fn rand(&mut self, inst: &AgcInst) -> u16 ;
+    fn wor(&mut self, inst: &AgcInst) -> u16 ;
+    fn wand(&mut self, inst: &AgcInst) -> u16 ;
+    fn read_instr(&mut self, inst: &AgcInst) -> u16 ;
+    fn write_instr(&mut self, inst: &AgcInst) -> u16 ;
+    fn rxor(&mut self, inst: &AgcInst) -> u16 ;
 }
 
 impl AgcIo for AgcCpu {
@@ -33,9 +33,7 @@ impl AgcIo for AgcCpu {
     /// with the overflow-corrected accumulator, and the result is sign-extended
     /// to 16 bits before storage in A.
     ///
-    fn ror(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn ror(&mut self, inst: &AgcInst) -> u16  {
         let k = inst.get_data_bits() & 0x1FF;
         let io_val = self.read_io(k as usize);
 
@@ -49,7 +47,7 @@ impl AgcIo for AgcCpu {
                 self.write_s15(REG_A, n & 0x7FFF);
             }
         };
-        true
+        2
     }
 
     ///
@@ -70,9 +68,7 @@ impl AgcIo for AgcCpu {
     /// with the overflow-corrected accumulator, and the result is sign-extended
     /// to 16 bits before storage in A.
     ///
-    fn rand(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn rand(&mut self, inst: &AgcInst) -> u16  {
         let k = inst.get_data_bits() & 0x1FF;
         let io_val = self.read_io(k as usize);
 
@@ -86,7 +82,7 @@ impl AgcIo for AgcCpu {
                 self.write_s15(REG_A, n & 0x7FFF);
             }
         };
-        true
+        2
     }
 
     ///
@@ -107,9 +103,7 @@ impl AgcIo for AgcCpu {
     /// with the overflow-corrected accumulator, and the result is sign-extended
     /// to 16 bits before storage in A.
     ///
-    fn rxor(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn rxor(&mut self, inst: &AgcInst) -> u16  {
         let k = inst.get_data_bits() & 0x1FF;
         let io_val = self.read_io(k as usize);
 
@@ -123,7 +117,7 @@ impl AgcIo for AgcCpu {
                 self.write_s15(REG_A, n & 0x7FFF);
             }
         };
-        true
+        2
     }
 
     ///
@@ -144,9 +138,7 @@ impl AgcIo for AgcCpu {
     /// destination is logically ORed with the overflow-corrected accumulator and
     /// stored to K, and the result is sign-extended to 16 bits before storage in A.
     ///
-    fn wor(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn wor(&mut self, inst: &AgcInst) -> u16  {
         let k: usize = (inst.get_data_bits() & 0x1FF) as usize;
         let io_val = self.read_io(k);
 
@@ -164,7 +156,7 @@ impl AgcIo for AgcCpu {
                 self.write_io(k, n & 0x7FFF);
             }
         };
-        true
+        2
     }
 
     ///
@@ -185,9 +177,7 @@ impl AgcIo for AgcCpu {
     /// destination is logically ANDed with the overflow-corrected accumulator and
     /// stored to K, and the result is sign-extended to 16 bits before storage in A.
     ///
-    fn wand(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn wand(&mut self, inst: &AgcInst) -> u16  {
         let k: usize = (inst.get_data_bits() & 0x1FF) as usize;
         let io_val = self.read_io(k);
 
@@ -203,7 +193,7 @@ impl AgcIo for AgcCpu {
                 self.write_io(k, n & 0x7FFF);
             }
         };
-        true
+        2
     }
 
     ///
@@ -218,16 +208,14 @@ impl AgcIo for AgcCpu {
     ///     the 16-bit value is read. Otherwise, value to sign extended and stored
     ///     into A register
     ///
-    fn read_instr(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
-
+    fn read_instr(&mut self, inst: &AgcInst) -> u16  {
         let k = inst.get_data_bits() & 0x1FF;
         let io_val = match k {
             2 => self.read_io(k as usize),
             _ => sign_extend(self.read_io(k as usize)),
         };
         self.write_s16(REG_A, io_val);
-        true
+        2
     }
 
     ///
@@ -242,8 +230,8 @@ impl AgcIo for AgcCpu {
     ///     16-bit value of A is stored into K.  Otherwise, the value is
     ///     overflow-corrected before storage.
     ///
-    fn write_instr(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
+    fn write_instr(&mut self, inst: &AgcInst) -> u16  {
+
 
         let k = inst.get_data_bits() & 0x1FF;
         let val = self.read_s16(REG_A);
@@ -255,7 +243,7 @@ impl AgcIo for AgcCpu {
                 self.write_io(k as usize, overflow_correction(val) & 0x7FFF);
             }
         }
-        true
+        2
     }
 }
 

--- a/src/instr/logic.rs
+++ b/src/instr/logic.rs
@@ -3,7 +3,7 @@ use crate::cpu;
 use crate::cpu::*;
 
 pub trait AgcLogic {
-    fn mask(&mut self, inst: &AgcInst) -> bool;
+    fn mask(&mut self, inst: &AgcInst) -> u16;
 }
 
 impl AgcLogic for AgcCpu {
@@ -25,8 +25,7 @@ impl AgcLogic for AgcCpu {
     /// overflow-corrected accumulator, and the result is sign-extended to
     /// 16-bits before storage in A.
     ///
-    fn mask(&mut self, inst: &AgcInst) -> bool {
-        self.cycles = 2;
+    fn mask(&mut self, inst: &AgcInst) -> u16 {
         let k = inst.get_kaddr();
         match k {
             cpu::REG_A | cpu::REG_Q => {
@@ -41,6 +40,6 @@ impl AgcLogic for AgcCpu {
                 self.write_s15(REG_A, n & 0x7FFF);
             }
         };
-        true
+        2
     }
 }

--- a/src/mem/periph/dsky.rs
+++ b/src/mem/periph/dsky.rs
@@ -1,7 +1,7 @@
 use crate::utils::{generate_yaagc_packet, parse_yaagc_packet};
 
 use crossbeam_channel::{unbounded, Receiver, Sender};
-use log::debug;
+use log::{debug, warn};
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -91,15 +91,15 @@ fn handle_stream_input(stream: &mut TcpStream, keypress_tx: &Sender<u16>) {
             Ok(_x) => match parse_yaagc_packet(buf) {
                 Some(res) => match res.0 {
                     0o15 => {
-                        println!("Keypress: {:o}", res.1);
+                        debug!("Keypress: {:o}", res.1);
                         let _res = keypress_tx.send(res.1);
                     }
                     0o32 => {
-                        println!("Keypress (Proceed): {:o}", res.1);
+                        debug!("Keypress (Proceed): {:o}", res.1);
                         let _res = keypress_tx.send(res.1 | 0o40000);
                     }
                     _ => {
-                        println!("Unimplemented keypress: {:?}", res);
+                        warn!("Unimplemented keypress: {:?}", res);
                     }
                 },
                 _ => {}
@@ -280,7 +280,7 @@ impl DskyDisplay {
     /// CHANNEL_DSALMOUT
     pub fn set_dsalmout_flags(&mut self, flags: u16) {
         if self.last_dsalmout != flags {
-            println!("DSKY: Setting CHANNEL_DSALMOUT Flags: {:o}", flags);
+            debug!("DSKY: Setting CHANNEL_DSALMOUT Flags: {:o}", flags);
             self.last_dsalmout = flags;
             self.dsky_tx
                 .send(generate_yaagc_packet(0o11, flags))
@@ -385,7 +385,6 @@ impl super::Peripheral for DskyDisplay {
             let val = self.keypress.recv().unwrap();
             match val & 0o40000 {
                 0o40000 => {
-                    println!("val: {:5o}", val);
                     self.proceed = val & 0o37777;
                 }
                 _ => {


### PR DESCRIPTION
Changed the way in which MCT cycles are being reported for each executed instruction. Prior to this, each instruction would modify a public structure variable, `cycles`. Since the return value for `step` and associated instruction execution (`bool`) was not being used. It was refactored to return the number of cycles executed `u16`