### PR TITLE
Updated Rope Core and Rust Workspace

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ROM filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ragc-build.yml
+++ b/.github/workflows/ragc-build.yml
@@ -4,26 +4,38 @@ jobs:
   build-ragc-debug:
     runs-on: ubuntu-latest
     container:
-      image: rust:alpine
+      image: rust:buster
     steps:
+      - name: Install Additional Deps
+        run: apt update && apt install -y git git-lfs
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Check ROM files from checkout
+        run: ls -al ./ragc-ropes/res
       - name: Build Rust Project (Debug)
         run: cargo build
 
   run-ragc-tests:
     runs-on: ubuntu-latest
     container:
-      image: rust:alpine
+      image: rust:buster
     needs:
       build-ragc-debug
     strategy:
       matrix:
         test_name: [
-          "mem::timer", "mem::tests", "mem::ram",
+          "mem::timer", "mem::ram",
           "mem::rom", "mem::edit", "utils::"]
     steps:
+      - name: Install Additional Deps
+        run: apt update && apt install -y git git-lfs
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Check ROM files from checkout
+        run: ls -al ./ragc-ropes/res
       - name: Run Test ${{matrix.test_name}}
         run: cargo test ${{matrix.test_name}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "ragc-ropes",
     "ragc-core",
     "ragc"
 ]

--- a/README.md
+++ b/README.md
@@ -26,16 +26,24 @@ cargo build --release
 
 ## Running
 
-To run `ragc`, the emulator needs to know where it can load in the rope core
-binary that would be stored within a given AGC. Example binaries and methods to
-compile AGC4 code can be found at the VirtualAGC website, which information can
-be found in the [Resources](#Resources) section of this document.
+The `ragc` CLI provides the ability to run AGC ROM code via file or through
+prebuilt images provided by the `ragc-ropes` package. To run a prebuilt ROM
+image, the following command demonstrates how to run the RETREAD50 program
 
-Once an AGC rope core binary is obtained, running `ragc` is the same for running
-any Cargo application. The following command documents an example usage of this:
+```bash
+cargo run -- retread50
+```
+
+The subcommand `file` can be used to run an external AGC ROM via a file. Example
+binaries and ability to compile AGC4 code can be found at the VirtualAGC website.
+The link to the VirtualAGC site be found in the [Resources](#Resources) section
+of this document.
+
+Once an AGC rope core binary is obtained, the following command demonstrates how
+to run `ragc` with a custom ROM image:
 
 ```rust
-cargo run (binary path)
+cargo run -- file (binary path)
 ```
 
 Addtional flags and options can be used while running `ragc`.
@@ -47,7 +55,7 @@ Addtional flags and options can be used while running `ragc`.
   specify `RUST_LOG` environment variable with the level of logging desired.
   For example:
     ```rust
-    RUST_LOG=info cargo run --release (binary path)
+    RUST_LOG=info cargo run --release file (binary path)
     ```
 ## Supporting Peripherials
 
@@ -124,11 +132,6 @@ time. I hope to add more to this list over time as more resources are found.
 but is successful for RETREAD50.
  - Implement the IMU and inertial sensors in order to provide sensor data and emulate
 one of the programs within LUMINARY/COLOSSUS
- - Implement the various rebooting logic that goes with the AGC computer architecture
-   - Unprogrammed GOJAM implementation
-   - WATCHMEN implementation
-   - Too many TC instructions causes GOJAM
-   - Many others that I may or maynot know about
  - Reshape the codebase into a more library format. (i.e. - ragc-core, ragc-dsky, etc)
 to reduce the amount of std libraries needed for the ragc-core
  - Revisit the DOWNRUPT and implement the interface to allow for integration

--- a/ragc-core/Cargo.toml
+++ b/ragc-core/Cargo.toml
@@ -9,7 +9,11 @@ license = "MIT OR Apache-2.0"
 log = "0.4"
 env_logger = "0.8.4"
 crossbeam-channel = "0.5"
-heapless = "*"
+heapless = "0.7.7"
+
+[dev-dependencies]
+ragc-ropes = {path = "../ragc-ropes"}
+
 
 [features]
 default = ["std"]

--- a/ragc-core/src/cpu.rs
+++ b/ragc-core/src/cpu.rs
@@ -81,8 +81,8 @@ trait AgcUnprogInstr {
 }
 
 #[allow(dead_code)]
-pub struct AgcCpu {
-    mem: AgcMemoryMap,
+pub struct AgcCpu<'a> {
+    mem: AgcMemoryMap<'a>,
     pub ir: u16,
     pub idx_val: u16,
     pub ec_flag: bool,
@@ -105,7 +105,7 @@ pub struct AgcCpu {
     ruptlock_count: i32,
 }
 
-impl AgcUnprogInstr for AgcCpu {
+impl <'a>AgcUnprogInstr for AgcCpu<'a> {
     fn handle_goj(&mut self) -> u16 {
         debug!("Handling GOJ (Restart of AGC)");
 
@@ -151,7 +151,7 @@ impl AgcUnprogInstr for AgcCpu {
     }
 }
 
-impl AgcCpu {
+impl <'a>AgcCpu<'a> {
     ///
     /// ## `calculate_instr_data` Function
     ///

--- a/ragc-core/src/instr/arith.rs
+++ b/ragc-core/src/instr/arith.rs
@@ -88,7 +88,7 @@ pub trait AgcArith {
     fn dv(&mut self, inst: &AgcInst) -> u16;
 }
 
-impl AgcArith for AgcCpu {
+impl<'a> AgcArith for AgcCpu<'a> {
     fn ad(&mut self, inst: &AgcInst) -> u16 {
         let a = self.read_s16(REG_A) as u16;
         let k = self.read_s16(inst.get_kaddr()) as u16;

--- a/ragc-core/src/instr/cf.rs
+++ b/ragc-core/src/instr/cf.rs
@@ -11,7 +11,7 @@ pub trait AgcControlFlow {
     fn tc(&mut self, inst: &AgcInst) -> u16;
 }
 
-impl AgcControlFlow for AgcCpu {
+impl <'a>AgcControlFlow for AgcCpu<'a> {
     fn bzf(&mut self, inst: &AgcInst) -> u16 {
         self.ec_flag = false;
 

--- a/ragc-core/src/instr/intrpt.rs
+++ b/ragc-core/src/instr/intrpt.rs
@@ -8,7 +8,7 @@ pub trait AgcInterrupt {
     fn resume(&mut self, inst: &AgcInst) -> u16;
 }
 
-impl AgcInterrupt for AgcCpu {
+impl <'a>AgcInterrupt for AgcCpu<'a> {
     fn inhint(&mut self, _inst: &AgcInst) -> u16 {
         self.gint = false;
         1

--- a/ragc-core/src/instr/io.rs
+++ b/ragc-core/src/instr/io.rs
@@ -14,7 +14,7 @@ pub trait AgcIo {
     fn rxor(&mut self, inst: &AgcInst) -> u16 ;
 }
 
-impl AgcIo for AgcCpu {
+impl <'a>AgcIo for AgcCpu<'a> {
     ///
     /// ## ROR instruction
     ///

--- a/ragc-core/src/instr/ldst.rs
+++ b/ragc-core/src/instr/ldst.rs
@@ -16,7 +16,7 @@ pub trait AgcLoadStore {
     fn ts(&mut self, inst: &AgcInst) -> u16;
 }
 
-impl AgcLoadStore for AgcCpu {
+impl <'a>AgcLoadStore for AgcCpu<'a> {
     fn cs(&mut self, inst: &AgcInst) -> u16 {
         let addr: usize = inst.get_data_bits() as usize;
         let mut val = self.read_s16(addr);

--- a/ragc-core/src/instr/logic.rs
+++ b/ragc-core/src/instr/logic.rs
@@ -6,7 +6,7 @@ pub trait AgcLogic {
     fn mask(&mut self, inst: &AgcInst) -> u16;
 }
 
-impl AgcLogic for AgcCpu {
+impl <'a>AgcLogic for AgcCpu<'a> {
     ///
     /// ## MASK instruction
     ///

--- a/ragc-core/src/instr/mod.rs
+++ b/ragc-core/src/instr/mod.rs
@@ -12,8 +12,6 @@ pub use io::AgcIo;
 pub use ldst::AgcLoadStore;
 pub use logic::AgcLogic;
 
-pub mod tests;
-
 const DATA_MASK: u16 = 0o7777; // 0xFFF
 const DATA_MASK_RAM: u16 = 0o1777; // 0x3FF
 const OPCODE_MASK: u16 = 0o7;
@@ -128,6 +126,9 @@ impl AgcInst {
         }
     }
 }
+
+#[cfg(test)]
+pub mod tests;
 
 #[cfg(test)]
 mod disasm_tests {

--- a/ragc-core/src/instr/tests/mod.rs
+++ b/ragc-core/src/instr/tests/mod.rs
@@ -2,13 +2,16 @@ use crate::cpu;
 use crate::cpu::AgcCpu;
 use crate::mem;
 use heapless::spsc::Queue;
+use ragc_ropes;
 
 #[allow(dead_code)]
-pub fn init_agc() -> AgcCpu {
+pub fn init_agc<'a>() -> AgcCpu<'a> {
     let mut rupt_queue = Queue::new();
     let (rupt_tx, _rupt_rx) = rupt_queue.split();
 
-    let mut mm = mem::AgcMemoryMap::new_blank(rupt_tx);
+    let program = ragc_ropes::LUMINARY131_ROPE;
+
+    let mut mm = mem::AgcMemoryMap::new(program ,rupt_tx);
     mm.enable_rom_write();
     let mut _cpu = cpu::AgcCpu::new(mm);
 

--- a/ragc-core/src/mem/rom.rs
+++ b/ragc-core/src/mem/rom.rs
@@ -1,6 +1,4 @@
-use log::{error, info, warn};
-use std::fs::File;
-use std::io::Read;
+use log::{info, warn};
 
 use crate::mem::AgcMemType;
 
@@ -11,19 +9,22 @@ const DATA_LINE_PART_LEN: usize = 6;
 pub const ROM_BANKS_NUM: usize = 36;
 pub const ROM_BANK_NUM_WORDS: usize = 1024;
 
-#[derive(Clone)]
-pub struct AgcRom {
-    //filepath: String,
-    bank_idx: u8,
-    line_cnt: u8,
-    parity: u8,
-    banks: [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM],
+
+enum Option<T> {
+    None,
+    Some(T)
 }
+
+pub struct AgcRom<'a> {
+    program: Option<&'a [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM]>
+}
+
+
 
 // ============================================================================
 // Trait Implementations
 // ============================================================================
-impl AgcMemType for AgcRom {
+impl <'a>AgcMemType for AgcRom<'a> {
     fn read(&self, bank_idx: usize, bank_offset: usize) -> u16 {
         if bank_idx >= ROM_BANKS_NUM || bank_offset >= ROM_BANK_NUM_WORDS {
             warn!(
@@ -32,7 +33,22 @@ impl AgcMemType for AgcRom {
             );
             return 0x0;
         }
-        self.banks[bank_idx][bank_offset] & 0x7FFF
+        match self.program {
+            Option::Some(program) => {
+                const BANK_IDX_REF: [usize; 36] = [
+                    2, 3, 0, 1, 4, 5, 6, 7,
+                    8, 9, 10, 11, 12, 13, 14, 15,
+                    16, 17, 18, 19, 20, 21, 22, 23,
+                    24, 25, 26, 27, 28, 29, 30, 31,
+                    32, 33, 34, 35,
+                ];
+                (u16::from_be(program[BANK_IDX_REF[bank_idx]][bank_offset]) >> 1) & 0x7FFF
+            },
+            _ => {
+                0
+            }
+        }
+
     }
 
     fn write(&mut self, bank_idx: usize, bank_offset: usize, value: u16) {
@@ -43,74 +59,40 @@ impl AgcMemType for AgcRom {
             );
             return;
         }
-        self.banks[bank_idx][bank_offset] = value
+        warn!("Attempting to write to AGC ROM. Ignoring write {:03o}{:03o} <= {:05o}",
+                bank_idx, bank_offset, value);
     }
 }
 
-impl AgcRom {
-    pub fn new() -> AgcRom {
+impl <'a>AgcRom<'a> {
+    pub fn new(program: &'a [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM]) -> AgcRom {
         AgcRom {
-            bank_idx: 0,
-            line_cnt: 0,
-            parity: 0,
-            banks: [[0; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM],
+            program: Option::Some(program),
         }
     }
 
-    #[allow(dead_code)]
-    pub fn reset(&mut self) {
-        self.banks = [[0; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM];
-    }
-
-    pub fn load_agcbin_file(&mut self, filename: &str) -> Option<()> {
-        // Check to make sure we are able to open the file. If we are not
-        // able to, throw up the issue up to the caller to know we failed
-        // at opening the file.
-        let fp = File::open(filename);
-        let mut f = match fp {
-            Ok(f) => f,
-            _ => {
-                error!("Unable to open file: {:?}", filename);
-                return None;
-            }
-        };
-
-        let mut buf = [0; ROM_BANK_NUM_WORDS * 2];
-        let bank_idx_ref = [
-            2, 3, 0, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
-        ];
-
-        let mut bank_idx = 0;
-        loop {
-            match f.read_exact(&mut buf) {
-                Ok(_x) => {
-                    let mut word_idx = 0;
-                    for c in buf.chunks_exact(2) {
-                        let res = (c[0] as u16) << 8 | c[1] as u16;
-                        self.banks[bank_idx_ref[bank_idx]][word_idx] = res >> 1;
-                        word_idx += 1;
-                    }
-                }
-                Err(_x) => {
-                    break;
-                }
-            };
-            bank_idx += 1;
+    pub fn blank() -> AgcRom<'a> {
+        AgcRom {
+            program: Option::None
         }
-
-        None
     }
 
     #[allow(dead_code)]
     pub fn print_mem(&self) {
-        for (idx, b) in self.banks.iter().enumerate() {
-            info!("Bank {}", idx);
-            for v in b.chunks(8) {
-                info!(
-                    "\t{:04x} {:04x} {:04x} {:04x} {:04x} {:04x} {:04x} {:04x}",
-                    v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]
-                );
+        match self.program {
+            Option::Some(program) => {
+                for (idx, b) in program.iter().enumerate() {
+                    info!("Bank {}", idx);
+                    for v in b.chunks(8) {
+                        info!(
+                            "\t{:04x} {:04x} {:04x} {:04x} {:04x} {:04x} {:04x} {:04x}",
+                            v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]
+                        );
+                    }
+                }
+            },
+            Option::None => {
+                info!("ROM is Blank.");
             }
         }
     }
@@ -123,63 +105,3 @@ impl AgcRom {
 // ============================================================================
 // Module Tests
 // ============================================================================
-#[cfg(test)]
-mod agc_rom_tests {
-    use super::*;
-
-    #[test]
-    fn reset_test() {
-        let mut rom = AgcRom::new();
-
-        // Load with Random Value to ensure reset will do what it should be
-        // doing.
-        for i in 0..ROM_BANKS_NUM {
-            for j in 0..ROM_BANK_NUM_WORDS {
-                rom.banks[i][j] = 0xAA55;
-            }
-        }
-
-        // Reset
-        rom.reset();
-        for i in 0..ROM_BANKS_NUM {
-            for j in 0..ROM_BANK_NUM_WORDS {
-                assert_eq!(0, rom.banks[i][j]);
-            }
-        }
-    }
-
-    #[test]
-    fn read_test() {
-        let mut rom = AgcRom::new();
-        for i in 0..ROM_BANKS_NUM {
-            for j in 0..ROM_BANK_NUM_WORDS {
-                rom.reset();
-                rom.banks[i][j] = 0x55AA;
-                assert_eq!(
-                    0x55AA,
-                    rom.read(i, j),
-                    "Failed reading Bank {:?} Offset {:?}",
-                    i,
-                    j
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn write_test() {
-        let mut rom = AgcRom::new();
-
-        for i in 0..ROM_BANKS_NUM {
-            for j in 0..ROM_BANK_NUM_WORDS {
-                rom.reset();
-                rom.write(i, j, 0x55AA);
-                assert_eq!(
-                    0x55AA, rom.banks[i][j],
-                    "Failed Writing @ Bank {:?} Offset {:?}",
-                    i, j
-                );
-            }
-        }
-    }
-}

--- a/ragc-ropes/Cargo.toml
+++ b/ragc-ropes/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ragc-ropes"
+version = "0.1.0"
+authors = ["Felipe Vilas-Boas"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/ragc-ropes/res/LUMINARY131.ROM
+++ b/ragc-ropes/res/LUMINARY131.ROM
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feaba5ed5bb4c8b1df91c0ab6a9e434ee7ab7a3c825f5edea5187d8731c882e4
+size 73728

--- a/ragc-ropes/res/RETREAD50.ROM
+++ b/ragc-ropes/res/RETREAD50.ROM
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:944fc750ca461ad83c0266d7b2fd5af396207a5cd6c62df1d3f41186de6f8d80
+size 73728

--- a/ragc-ropes/res/VALIDATION.ROM
+++ b/ragc-ropes/res/VALIDATION.ROM
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff8a6baab6c10839da69f7b3a828e3981bc909570e36896e2eead311fd346545
+size 73728

--- a/ragc-ropes/src/lib.rs
+++ b/ragc-ropes/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+const ROM_BANKS_NUM: usize = 36;
+const ROM_BANK_NUM_WORDS: usize = 1024;
+
+macro_rules! include_transmute {
+    ($file:expr) => {
+        &core::mem::transmute(*include_bytes!($file))
+    };
+}
+
+pub static LUMINARY131_ROPE: &'static [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM] = unsafe { include_transmute!("../res/LUMINARY131.ROM") };
+pub static BLANK_ROPE: &'static [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM] = &[[0; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM];

--- a/ragc-ropes/src/lib.rs
+++ b/ragc-ropes/src/lib.rs
@@ -8,6 +8,7 @@ macro_rules! include_transmute {
         &core::mem::transmute(*include_bytes!($file))
     };
 }
-
+pub static RETREAD50_ROPE: &'static [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM] = unsafe { include_transmute!("../res/RETREAD50.ROM") };
+pub static VALIDATION_ROPE: &'static [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM] = unsafe { include_transmute!("../res/VALIDATION.ROM") };
 pub static LUMINARY131_ROPE: &'static [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM] = unsafe { include_transmute!("../res/LUMINARY131.ROM") };
 pub static BLANK_ROPE: &'static [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM] = &[[0; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM];

--- a/ragc/Cargo.toml
+++ b/ragc/Cargo.toml
@@ -13,3 +13,4 @@ heapless = "*"
 env_logger = "0.8.4"
 crossbeam-channel = "0.5"
 ragc-core = { path = "../ragc-core" }
+ragc-ropes = { path = "../ragc-ropes" }


### PR DESCRIPTION
- Updated to allow AGC ROM to take in binary as a parameter
- Reorganized project into Workspace and broken down project into `ragc` which is a CLI, `ragc-core` which is aiming to be a nostd library of the core AGC implementation, and `ragc-ropes` which is pre-built AGC ROM binaries.