### PR TITLE
Updating ragc-core to be nostd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@
 members = [
     "ragc-ropes",
     "ragc-core",
-    "ragc"
+    "ragc",
+    "ragc-vagc"
 ]

--- a/ragc-core/Cargo.toml
+++ b/ragc-core/Cargo.toml
@@ -12,8 +12,7 @@ crossbeam-channel = "0.5"
 heapless = "0.7.7"
 
 [dev-dependencies]
-ragc-ropes = {path = "../ragc-ropes"}
-
+ragc-ropes = { path = "../ragc-ropes" }
 
 [features]
 default = ["std"]

--- a/ragc-core/Cargo.toml
+++ b/ragc-core/Cargo.toml
@@ -7,13 +7,11 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 log = "0.4"
-env_logger = "0.8.4"
-crossbeam-channel = "0.5"
 heapless = "0.7.7"
 
 [dev-dependencies]
 ragc-ropes = { path = "../ragc-ropes" }
 
 [features]
-default = ["std"]
+default = []
 std = []

--- a/ragc-core/src/cpu.rs
+++ b/ragc-core/src/cpu.rs
@@ -767,6 +767,7 @@ impl <'a>AgcCpu<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod cpu_tests {
     use crate::cpu;
@@ -895,7 +896,6 @@ mod cpu_tests {
     #[test]
     fn cpu_test_tc_trap_reset_light() {
         let mut cpu = init_agc();
-
         let dur = std::time::Duration::from_secs(5);
         std::thread::sleep(dur);
         println!("Restarting AGC. Should indicate a RESTART light");

--- a/ragc-core/src/instr/arith.rs
+++ b/ragc-core/src/instr/arith.rs
@@ -58,6 +58,7 @@ fn convert_to_dp(upper: u16, lower: u16) -> u32 {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod convert_test {
     #[test]

--- a/ragc-core/src/instr/cf.rs
+++ b/ragc-core/src/instr/cf.rs
@@ -120,6 +120,7 @@ impl <'a>AgcControlFlow for AgcCpu<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod cfg_tests {
     use crate::cpu;

--- a/ragc-core/src/instr/io.rs
+++ b/ragc-core/src/instr/io.rs
@@ -247,6 +247,7 @@ impl <'a>AgcIo for AgcCpu<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod io_tests {
     use crate::cpu;

--- a/ragc-core/src/instr/ldst.rs
+++ b/ragc-core/src/instr/ldst.rs
@@ -158,6 +158,7 @@ impl <'a>AgcLoadStore for AgcCpu<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod ldst_tests {
     use crate::cpu;

--- a/ragc-core/src/instr/mod.rs
+++ b/ragc-core/src/instr/mod.rs
@@ -127,9 +127,11 @@ impl AgcInst {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 pub mod tests;
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod disasm_tests {
     use super::AgcInst;

--- a/ragc-core/src/instr/tests/mod.rs
+++ b/ragc-core/src/instr/tests/mod.rs
@@ -23,13 +23,6 @@ pub fn validate_cpu_state(cpu: &mut AgcCpu, expect_pc: u16) {
     assert_eq!(cpu.read(cpu::REG_Z), expect_pc);
 }
 
-mod init_tests {
-    #[test]
-    fn helloworld() {
-        env_logger::init();
-    }
-}
-
 mod ad;
 mod arith;
 mod logic;

--- a/ragc-core/src/lib.rs
+++ b/ragc-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub mod cpu;
 pub mod disasm;
 pub mod instr;

--- a/ragc-core/src/mem/mod.rs
+++ b/ragc-core/src/mem/mod.rs
@@ -1,6 +1,6 @@
 mod edit;
-mod io;
-mod periph;
+pub mod io;
+pub mod periph;
 mod ram;
 mod regs;
 mod rom;

--- a/ragc-core/src/mem/mod.rs
+++ b/ragc-core/src/mem/mod.rs
@@ -14,6 +14,8 @@ use heapless::spsc::Producer;
 
 use log::{error, trace};
 
+use self::periph::AgcIoPeriph;
+
 const _AGC_MM_RAMSIZE: usize = 1024;
 const _AGC_MM_ROMSIZE: usize = 3072;
 
@@ -33,7 +35,7 @@ trait AgcMemType {
 pub struct AgcMemoryMap<'a> {
     ram: ram::AgcRam,
     rom: rom::AgcRom<'a>,
-    io: io::AgcIoSpace,
+    io: io::AgcIoSpace<'a>,
     edit: edit::AgcEditRegs,
     special: special::AgcSpecialRegs,
     timers: timer::AgcTimers,
@@ -50,8 +52,8 @@ impl<'a> AgcMemoryMap<'a> {
             #[cfg(not(feature = "std"))]
             ram: ram::AgcRam::new(),
             rom: rom::AgcRom::blank(),
+            io: io::AgcIoSpace::blank(),
             edit: edit::AgcEditRegs::new(),
-            io: io::AgcIoSpace::new(),
             special: special::AgcSpecialRegs::new(rupt_tx),
             timers: timer::AgcTimers::new(),
             regs: regs::AgcRegs::new(),
@@ -60,7 +62,10 @@ impl<'a> AgcMemoryMap<'a> {
         }
     }
 
-    pub fn new(program: &'a [[u16; rom::ROM_BANK_NUM_WORDS]; rom::ROM_BANKS_NUM], rupt_tx: Producer<u8, 8>) -> AgcMemoryMap<'a> {
+    pub fn new(program: &'a [[u16; rom::ROM_BANK_NUM_WORDS]; rom::ROM_BANKS_NUM],
+               downrupt: &'a mut dyn AgcIoPeriph,
+               dsky: &'a mut dyn AgcIoPeriph,
+               rupt_tx: Producer<u8, 8>) -> AgcMemoryMap<'a> {
         AgcMemoryMap {
             #[cfg(feature = "std")]
             ram: ram::AgcRam::default(false),
@@ -68,7 +73,7 @@ impl<'a> AgcMemoryMap<'a> {
             ram: ram::AgcRam::new(),
             rom: rom::AgcRom::new(program),
             edit: edit::AgcEditRegs::new(),
-            io: io::AgcIoSpace::new(),
+            io: io::AgcIoSpace::new(downrupt, dsky),
             special: special::AgcSpecialRegs::new(rupt_tx),
             timers: timer::AgcTimers::new(),
             regs: regs::AgcRegs::new(),

--- a/ragc-core/src/mem/mod.rs
+++ b/ragc-core/src/mem/mod.rs
@@ -5,8 +5,10 @@ mod ram;
 mod regs;
 mod rom;
 mod special;
-mod tests;
 mod timer;
+
+#[cfg(feature = "std")]
+mod tests;
 
 pub use io::AgcIoSpace;
 

--- a/ragc-core/src/mem/periph/mod.rs
+++ b/ragc-core/src/mem/periph/mod.rs
@@ -1,5 +1,3 @@
-pub mod downrupt;
-pub mod dsky;
 pub mod engines;
 
 pub trait Peripheral {

--- a/ragc-core/src/mem/periph/mod.rs
+++ b/ragc-core/src/mem/periph/mod.rs
@@ -5,3 +5,8 @@ pub mod engines;
 pub trait Peripheral {
     fn is_interrupt(&mut self) -> u16;
 }
+pub trait AgcIoPeriph {
+    fn read(&self, _channel_idx: usize) -> u16;
+    fn write(&mut self, channel_idx: usize, value: u16);
+    fn is_interrupt(&mut self) -> u16;
+}

--- a/ragc-core/src/mem/ram.rs
+++ b/ragc-core/src/mem/ram.rs
@@ -23,6 +23,7 @@ impl AgcRam {
     pub fn new() -> AgcRam {
         AgcRam {
             banks: [[0; RAM_BANK_SIZE]; RAM_NUM_BANKS],
+            #[cfg(feature = "std")]
             enable_savestate: false,
         }
     }

--- a/ragc-core/src/mem/rom.rs
+++ b/ragc-core/src/mem/rom.rs
@@ -1,6 +1,7 @@
 use log::{info, warn};
 
 use crate::mem::AgcMemType;
+use crate::utils::Option as Option;
 
 #[allow(dead_code)]
 const DATA_LINE_NUM_PARTS: usize = 8;
@@ -9,17 +10,9 @@ const DATA_LINE_PART_LEN: usize = 6;
 pub const ROM_BANKS_NUM: usize = 36;
 pub const ROM_BANK_NUM_WORDS: usize = 1024;
 
-
-enum Option<T> {
-    None,
-    Some(T)
-}
-
 pub struct AgcRom<'a> {
     program: Option<&'a [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM]>
 }
-
-
 
 // ============================================================================
 // Trait Implementations

--- a/ragc-core/src/mem/tests.rs
+++ b/ragc-core/src/mem/tests.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod scalar_tests {
     use crate::cpu;

--- a/ragc-core/src/utils.rs
+++ b/ragc-core/src/utils.rs
@@ -1,3 +1,8 @@
+pub enum Option<T> {
+    None,
+    Some(T)
+}
+
 ///
 /// `overflow_correction` function handles 16 bit overflow correction.
 /// This function is to handle issues with overflow conditions when it comes
@@ -105,48 +110,6 @@ pub fn agc_dp_to_cpu(agc_val: u32) -> i32 {
     } else {
         (agc_val & 0o1777777777) as i32
     }
-}
-
-pub fn generate_yaagc_packet(channel: usize, value: u16) -> [u8; 4] {
-    [
-        0x0 | ((channel >> 3) & 0x1F) as u8,
-        0x40 | ((channel & 0x7) << 3) as u8 | ((value >> 12) & 0x7) as u8,
-        0x80 | ((value >> 6) & 0x3F) as u8,
-        0xC0 | (value & 0x3F) as u8,
-    ]
-}
-
-pub fn parse_yaagc_packet(msg: [u8; 4]) -> Option<(u16, u16)> {
-    let a;
-    let b;
-    let c;
-    let d;
-
-    match msg.len() {
-        4 => {
-            a = *msg.get(0).unwrap();
-            b = *msg.get(1).unwrap();
-            c = *msg.get(2).unwrap();
-            d = *msg.get(3).unwrap();
-        }
-        5 => {
-            a = *msg.get(0).unwrap();
-            b = *msg.get(1).unwrap();
-            c = *msg.get(2).unwrap();
-            d = *msg.get(3).unwrap();
-        }
-        _ => {
-            return None;
-        }
-    }
-
-    if a & 0xC0 != 0x00 || b & 0xC0 != 0x40 || c & 0xC0 != 0x80 || d & 0xC0 != 0xC0 {
-        return None;
-    }
-
-    let value: u16 = ((b as u16) & 0x7) << 12 | ((c as u16) & 0x3F) << 6 | ((d & 0x3F) as u16);
-    let channel: u16 = ((a as u16) & 0x3F) << 3 | ((b as u16) >> 3 & 0x7);
-    Some((channel, value))
 }
 
 #[cfg(test)]

--- a/ragc-vagc/Cargo.toml
+++ b/ragc-vagc/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ragc-vagc"
+version = "0.1.0"
+authors = ["Felipe Vilas-Boas"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+log = "0.4"
+env_logger = "0.8.4"
+crossbeam-channel = "0.5"
+ragc-core = { path = "../ragc-core" }

--- a/ragc-vagc/src/downrupt.rs
+++ b/ragc-vagc/src/downrupt.rs
@@ -1,0 +1,119 @@
+use super::generate_yaagc_packet;
+
+use crossbeam_channel::{unbounded, Receiver, Sender};
+use std::io::Write;
+use std::net::TcpListener;
+
+use ragc_core::mem::periph::AgcIoPeriph;
+
+pub struct DownruptPeriph {
+    tx: Sender<[u8; 4]>,
+    word_order: bool
+}
+
+fn downrupt_thread(rx: Receiver<[u8; 4]>, addr: &str) {
+    // accept connections and process them serially
+    let listener = TcpListener::bind(addr).unwrap();
+    for stream in listener.incoming() {
+        match stream {
+            Ok(mut xa) => loop {
+                let msg = match rx.recv() {
+                    Ok(x) => x,
+                    _ => {
+                        break;
+                    }
+                };
+
+                match xa.write_all(&msg) {
+                    Ok(_x) => {}
+                    _ => {
+                        break;
+                    }
+                }
+            },
+            _ => {}
+        };
+    }
+}
+
+///
+/// ## DownruptPeriph Module
+///
+/// The DownruptPeriph module is used to keep track of the downrupt message
+/// and send it back to ground control once all of it is collected. In reality,
+/// each double word is sent every 20ms. For this, we will buffer the entire
+/// message before we send it out. Also, keeps an eye for signatures within
+/// the start of the message.
+///
+impl DownruptPeriph {
+    pub fn new() -> Self {
+        let (tx, rx) = unbounded();
+
+        std::thread::spawn(move || downrupt_thread(rx, "127.0.0.1:19800"));
+        DownruptPeriph {
+            tx: tx,
+            word_order: false
+        }
+    }
+}
+
+impl AgcIoPeriph for DownruptPeriph {
+    ///
+    /// Implementing the `read` function for the Peripherial. For the Downrupt
+    /// peripherial, there is no `read`s that occur. For this, we just return
+    /// 0 to the code.
+    ///
+    fn read(&self, channel_idx: usize) -> u16 {
+        match channel_idx {
+            ragc_core::mem::io::CHANNEL_CHAN13 => {
+                if self.word_order {
+                    1 << 6
+                }
+                else {
+                    0o00000
+                }
+            }
+            ragc_core::mem::io::CHANNEL_CHAN30 |
+            ragc_core::mem::io::CHANNEL_CHAN31 |
+            ragc_core::mem::io::CHANNEL_CHAN32 |
+            ragc_core::mem::io::CHANNEL_CHAN33 |
+            ragc_core::mem::io::CHANNEL_CHAN34 |
+            ragc_core::mem::io::CHANNEL_CHAN35 => { 0o77777 }
+            _ => { 0o00000 }
+        }
+    }
+
+    ///
+    /// Implementing the `write` function for the Peripherial. This write does
+    /// not distinguish between DOWNRUPT WORD1 and DOWNRUPT WORD2 addresses.
+    /// Whichever order the code writes to the downrupt is reflected in the state
+    /// vector.
+    ///
+    /// Assumption: Code does not write to DOWNRUPT2 before DOWNRUPT1 word
+    ///
+    fn write(&mut self, channel_idx: usize, value: u16) {
+        match channel_idx {
+            ragc_core::mem::io::CHANNEL_CHAN13 => {
+                if value & (1 << 6) != 0o00000 {
+                    self.word_order = true;
+                }
+                else {
+                    self.word_order = false;
+                }
+            },
+            ragc_core::mem::io::CHANNEL_CHAN34 => {
+                let packet = generate_yaagc_packet(channel_idx, value);
+                self.tx.send(packet).unwrap();
+            }
+            ragc_core::mem::io::CHANNEL_CHAN35 => {
+                let packet = generate_yaagc_packet(channel_idx, value);
+                self.tx.send(packet).unwrap();
+            }
+            _ => {}
+        }
+    }
+
+    fn is_interrupt(&mut self) -> u16 {
+        0
+    }
+}

--- a/ragc-vagc/src/dsky.rs
+++ b/ragc-vagc/src/dsky.rs
@@ -1,0 +1,544 @@
+use super::{generate_yaagc_packet, parse_yaagc_packet};
+
+use crossbeam_channel::{unbounded, Receiver, Sender};
+use log::{debug, warn};
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+pub struct DskyDisplay {
+    digit: [u8; 15],
+    noun: u16,
+    verb: u16,
+    prog: u16,
+    proceed: u16,
+    output_flags: u16,
+    keypress: Receiver<u16>,
+    keypress_val: u16,
+    dsky_tx: Sender<[u8; 4]>,
+    flash_tx: Sender<u16>,
+    last_dsalmout: u16,
+    last_dskyval: u16,
+}
+
+const SEVEN_SEG_TABLE: [u8; 11] = [
+    // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, BLANK
+    0x3F, 0x06, 0x5B, 0x4F, 0x66, 0x6D, 0x7D, 0x07, 0x7F, 0x6F, 0x00,
+];
+
+///
+/// # Description
+///
+/// The function is to convert the bits being set by the AGC code within a given
+/// IO channel, to the corresponding seven segment display value. These values
+/// will help properly display a given value
+///
+/// # Arguments
+///
+///  - `agc_val` - Typical 5 bit code value that is used in CHANNEL_DSKY.
+///
+/// # Return Value
+///
+///  - 7 Segment value code
+///
+fn get_7seg(agc_val: u8) -> u8 {
+    // This match is to convert the agc_val bits that is being fed into the
+    // IO channel to the corresponding 7 Segment Display Value.
+    match agc_val {
+        0 => SEVEN_SEG_TABLE[10],
+        21 => SEVEN_SEG_TABLE[0],
+        3 => SEVEN_SEG_TABLE[1],
+        25 => SEVEN_SEG_TABLE[2],
+        27 => SEVEN_SEG_TABLE[3],
+        15 => SEVEN_SEG_TABLE[4],
+        30 => SEVEN_SEG_TABLE[5],
+        28 => SEVEN_SEG_TABLE[6],
+        19 => SEVEN_SEG_TABLE[7],
+        29 => SEVEN_SEG_TABLE[8],
+        31 => SEVEN_SEG_TABLE[9],
+        _ => SEVEN_SEG_TABLE[10],
+    }
+}
+
+///
+/// # Description
+///
+/// The function is to convert the bits being set by the AGC code within a given
+/// IO channel, to the corresponding seven segment display value. These values
+/// will help properly display a given value
+///
+/// # Arguments
+///
+///  - `c` - Typical 5 bit code value that is used in CHANNEL_DSKY. This value
+///          represents the upper nibble of a byte display.
+///  - `d` - Typical 5 bit code value that is used in CHANNEL_DSKY. This value
+///          represents the upper nibble of a byte display.
+/// # Return Value
+///
+///  - `u16` - Value that contains both upper and lower nibble 7 segment display
+///            value.
+///
+fn get_7seg_value(c: u8, d: u8) -> u16 {
+    let mut res: u16 = get_7seg(c) as u16;
+    res = res << 8 | get_7seg(d) as u16;
+    res
+}
+
+fn handle_stream_input(stream: &mut TcpStream, keypress_tx: &Sender<u16>) {
+    loop {
+        let mut buf = [0; 4];
+        match stream.read_exact(&mut buf) {
+            Ok(_x) => match parse_yaagc_packet(buf) {
+                Some(res) => match res.0 {
+                    0o15 => {
+                        debug!("Keypress: {:o}", res.1);
+                        let _res = keypress_tx.send(res.1);
+                    }
+                    0o32 => {
+                        debug!("Keypress (Proceed): {:o}", res.1);
+                        let _res = keypress_tx.send(res.1 | 0o40000);
+                    }
+                    _ => {
+                        warn!("Unimplemented keypress: {:?}", res);
+                    }
+                },
+                _ => {}
+            },
+            _ => {
+                break;
+            }
+        }
+    }
+    println!("Stream Input: Disconnecting from stream session");
+}
+
+fn handle_steam_output(stream: &mut TcpStream, dsky_rx: &Receiver<[u8; 4]>) {
+    loop {
+        let msg = match dsky_rx.recv() {
+            Ok(x) => x,
+            _ => {
+                break;
+            }
+        };
+
+        match stream.write_all(&msg) {
+            Ok(_x) => {}
+            _ => {
+                break;
+            }
+        }
+    }
+    println!("Stream Output: Disconnecting from stream session");
+}
+
+fn flashing_thread(flash_rx: Receiver<u16>, dsky_tx: Sender<[u8; 4]>) {
+    let mut channel_value = 0o00000;
+    let start_time = std::time::SystemTime::now();
+
+    loop {
+        while !flash_rx.is_empty() {
+            channel_value = flash_rx.recv().unwrap();
+        }
+
+        let elapsed = start_time.elapsed().unwrap().as_millis();
+        if elapsed % 1000 < 750 {
+            let mut value = channel_value;
+            if channel_value & 0o00040 == 0o00040 {
+                value &= !0o00040;
+            }
+            dsky_tx.send(generate_yaagc_packet(0o0163, value)).unwrap();
+        } else {
+            if channel_value != 0o00000 {
+                let mut value = channel_value & !0o00160;
+                if channel_value & 0o00040 == 0o00040 {
+                    value |= 0o00040;
+                }
+                dsky_tx.send(generate_yaagc_packet(0o0163, value)).unwrap();
+            }
+        }
+
+        std::thread::sleep(std::time::Duration::new(0, 10000000));
+    }
+}
+
+fn dsky_network_thread(keypress_tx: Sender<u16>, dsky_rx: Receiver<[u8; 4]>) {
+    // accept connections and process them serially
+    let listener = TcpListener::bind("127.0.0.1:19697").unwrap();
+    for stream in listener.incoming() {
+        println!("Connecting to new stream");
+        match stream {
+            Ok(mut xa) => {
+                match xa.try_clone() {
+                    Ok(mut x) => {
+                        let keypresstx = keypress_tx.clone();
+                        std::thread::spawn(move || handle_stream_input(&mut x, &keypresstx));
+                    }
+                    _ => {
+                        continue;
+                    }
+                }
+                handle_steam_output(&mut xa, &dsky_rx);
+            }
+            _ => {}
+        };
+        println!("Disconnecting");
+    }
+}
+
+impl DskyDisplay {
+    pub fn new() -> Self {
+        let (keypress_tx, keypress_rx) = unbounded();
+        let (dsky_tx, dsky_rx) = unbounded();
+        let (flash_tx, flash_rx) = unbounded();
+
+        let flash_dsky_tx = dsky_tx.clone();
+        std::thread::spawn(move || flashing_thread(flash_rx, flash_dsky_tx));
+        std::thread::spawn(move || dsky_network_thread(keypress_tx, dsky_rx));
+
+        Self {
+            digit: [0; 15],
+            noun: 0,
+            verb: 0,
+            prog: 0,
+            keypress: keypress_rx,
+            keypress_val: 0,
+            proceed: 0o20000,
+            dsky_tx: dsky_tx,
+            flash_tx: flash_tx,
+            output_flags: 0x0,
+            last_dsalmout: 0x0,
+            last_dskyval: 0x0,
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// The function parses the CHANNEL_DSKY IO channel value into multiple parts
+    /// that is used to capture the display nibbles and rows in which it is being
+    /// displayed on.
+    ///
+    /// # Return Value
+    ///
+    /// - (u8 a, bool b, u8 c, u8 d)
+    ///   - `a` - Represents the rown in which the decoding is being performed on
+    ///   - `b` - Represents the boolean flag for some rows which determines the
+    ///           positive or negative display flags for a given DSKY value
+    ///   - `c` - Upper nibble of a given value on the DSKY
+    ///   - `d` - Lower nibble of a given value on the DSKY
+    ///
+    fn parse_fields(&self, val: u16) -> (u8, bool, u8, u8) {
+        let a: u8 = ((val >> 11) & 0xF) as u8;
+        let c: u8 = ((val >> 5) & 0x1F) as u8;
+        let d: u8 = (val & 0x1F) as u8;
+        let b: bool = if val & (1 << 10) == (1 << 10) {
+            true
+        } else {
+            false
+        };
+        (a, b, c, d)
+    }
+
+    pub fn read_keypress(&self) -> u16 {
+        debug!("DSKY: Reading keypress: {:?}", self.keypress_val);
+        self.keypress_val & 0x1F
+    }
+
+    pub fn set_channel_value(&mut self, channel_idx: usize, value: u16) {
+        match channel_idx {
+            0o13 => {
+                if value & 0o01000 != 0o00000 {
+                    self.output_flags |= 0o00400;
+                } else {
+                    self.output_flags &= 0o77377;
+                }
+                self.flash_tx.send(self.output_flags).unwrap();
+            }
+            0o163 => {
+                self.output_flags = value;
+                self.flash_tx.send(self.output_flags).unwrap();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn get_channel_value(&self, channel_idx: usize) -> u16 {
+        match channel_idx {
+            0o163 => self.output_flags & 0o1771,
+            _ => 0o00000,
+        }
+    }
+
+    pub fn read_proceed_flag(&self) -> u16 {
+        self.proceed
+    }
+
+    ///
+    /// # Description
+    ///
+    /// This function is to set additional flags that is being controlled via
+    /// CHANNEL_DSALMOUT
+    pub fn set_dsalmout_flags(&mut self, flags: u16) {
+        if self.last_dsalmout != flags {
+            debug!("DSKY: Setting CHANNEL_DSALMOUT Flags: {:o}", flags);
+            self.last_dsalmout = flags;
+            self.dsky_tx
+                .send(generate_yaagc_packet(0o11, flags))
+                .unwrap();
+
+            self.output_flags = (self.output_flags & 0o77607) | (flags & 0o00170);
+            self.flash_tx.send(self.output_flags).unwrap();
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// This function is to handle row value 12 (decimal) for CHANNEL_DSKY which
+    /// is different than all the other rows. This row handles specific light
+    /// indicators within the DSKYr
+    ///
+    /// # Arguments
+    ///
+    /// - `flags` - Bitfield for row 12 which represents the specific indicators
+    ///             for that row.
+    ///
+    pub fn set_adv_flags(&mut self, _flags: u16) {
+        //println!("DSKY: Setting Adv Flags: {:x}", flags);
+        //self.lamps = (self.lamps & 0xFF) | ((flags as u32) << 8);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// This function is to handle new CHANNEL_DSKY values being set by the AGC.
+    /// The function will parse the value and handle the appropriate display to
+    /// update.
+    ///
+    /// # Arguments
+    ///
+    /// - `val` - Value that was written via the CHANNEL_DSKY io port.
+    ///
+    pub fn set_channel_dsky_value(&mut self, val: u16) {
+        if self.last_dskyval == val {
+            return;
+        }
+
+        //println!("DSKY: Setting CHANNEL_DSKY Value: {:x}", val);
+        self.last_dskyval = val;
+        self.dsky_tx.send(generate_yaagc_packet(0o10, val)).unwrap();
+
+        let (a, _b, c, d) = self.parse_fields(val);
+        match a {
+            1 => {
+                self.digit[13] = get_7seg(c);
+                self.digit[14] = get_7seg(d);
+            }
+            2 => {
+                self.digit[11] = get_7seg(c);
+                self.digit[12] = get_7seg(d);
+            }
+            3 => {
+                self.digit[9] = get_7seg(c);
+                self.digit[10] = get_7seg(d);
+            }
+            4 => {
+                self.digit[7] = get_7seg(c);
+                self.digit[8] = get_7seg(d);
+            }
+            5 => {
+                self.digit[5] = get_7seg(c);
+                self.digit[6] = get_7seg(d);
+            }
+            6 => {
+                self.digit[3] = get_7seg(c);
+                self.digit[4] = get_7seg(d);
+            }
+            7 => {
+                self.digit[1] = get_7seg(c);
+                self.digit[2] = get_7seg(d);
+            }
+            8 => {
+                self.digit[0] = get_7seg(d);
+            }
+            11 => {
+                self.prog = get_7seg_value(c, d);
+            }
+            10 => {
+                self.verb = get_7seg_value(c, d);
+            }
+            9 => {
+                self.noun = get_7seg_value(c, d);
+            }
+            12 => {
+                self.set_adv_flags(val & 0x7FF);
+            }
+            _ => {}
+        };
+        debug!("DSKY: {:?}", self.digit);
+    }
+}
+
+impl ragc_core::mem::periph::AgcIoPeriph for DskyDisplay {
+    fn read(&self, channel_idx: usize) -> u16 {
+        match channel_idx {
+            ragc_core::mem::io::CHANNEL_MNKEYIN => {
+                self.read_keypress()
+            }
+            ragc_core::mem::io::CHANNEL_CHAN30 => 0o77777,
+            ragc_core::mem::io::CHANNEL_CHAN31 => 0o77777,
+            ragc_core::mem::io::CHANNEL_CHAN32 => {
+                self.read_proceed_flag()
+            }
+            ragc_core::mem::io::CHANNEL_CHAN33 => 0o77777,
+            0o163 => self.get_channel_value(channel_idx),
+            _ => { 0o00000 }
+        }
+    }
+
+    fn write(&mut self, channel_idx: usize, value: u16) {
+        match channel_idx {
+            ragc_core::mem::io::CHANNEL_DSKY => {
+                self.set_channel_dsky_value(value);
+            },
+            ragc_core::mem::io::CHANNEL_DSALMOUT => {
+                self.set_dsalmout_flags(value);
+            }
+            ragc_core::mem::io::CHANNEL_CHAN13 => {
+                self.set_channel_value(channel_idx, value);
+            }
+            0o163 => {
+                self.set_channel_value(channel_idx, value);
+            }
+            _ => { }
+        }
+
+    }
+
+    fn is_interrupt(&mut self) -> u16 {
+        if self.keypress.len() > 0 {
+            let val = self.keypress.recv().unwrap();
+            match val & 0o40000 {
+                0o40000 => {
+                    self.proceed = val & 0o37777;
+                }
+                _ => {
+                    self.keypress_val = val;
+                    if self.keypress_val == 0o22 {
+                        let io_val = self.get_channel_value(0o163);
+                        self.set_channel_value(0o163, io_val & !0o00200);
+                    }
+                }
+            }
+            (1 << ragc_core::cpu::RUPT_KEY1) as u16
+        } else {
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod dsky_unittests {
+    use super::DskyDisplay;
+
+    const AGC_SEG_TABLE: [u8; 11] = [
+        // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, Blank
+        21, 3, 25, 27, 15, 30, 28, 19, 29, 31, 0,
+    ];
+
+    ///
+    /// # Description
+    ///
+    /// # Arguments
+    ///
+    ///  -  `row_idx` - `u16` - Row within the CHANNEL_OUT0 encoding to update
+    ///     a given digit nibble
+    ///  - `digit_idx` - `usize` - Index into the `DskyState.digits` array in
+    ///    which to compare the values
+    ///
+    fn dsky_display_digit_index(
+        dsky: &mut DskyDisplay,
+        row_idx: u16,
+        lower_digit_seg: &u8,
+        upper_digit_seg: &u8,
+    ) {
+        let value: u16 =
+            (row_idx << 11) | *lower_digit_seg as u16 | ((*upper_digit_seg as u16) << 5);
+        dsky.set_channel_dsky_value(value);
+    }
+
+    #[test]
+    fn test_dsky_display_flags_yaagc() {
+        let mut dsky = super::DskyDisplay::new();
+
+        let mut value: u16 = (10 << 11) | 0o3 | 0o3;
+        dsky.set_channel_dsky_value(value);
+        value = (9 << 11) | 0o3 | 0o3;
+        dsky.set_channel_dsky_value(value);
+
+        for i in 0..8 {
+            dsky.set_dsalmout_flags(1 << i);
+            std::thread::sleep(std::time::Duration::new(5, 0));
+            dsky.set_dsalmout_flags(0o0);
+            std::thread::sleep(std::time::Duration::new(5, 0));
+        }
+    }
+
+    #[test]
+    fn test_dsky_display_flashing_yaagc() {
+        let mut dsky = super::DskyDisplay::new();
+        std::thread::sleep(std::time::Duration::new(5, 0));
+        dsky_display_digit_index(
+            &mut dsky,
+            10,
+            AGC_SEG_TABLE.get(7).unwrap(),
+            AGC_SEG_TABLE.get(7).unwrap(),
+        );
+        dsky_display_digit_index(
+            &mut dsky,
+            9,
+            AGC_SEG_TABLE.get(7).unwrap(),
+            AGC_SEG_TABLE.get(7).unwrap(),
+        );
+        let mut val = 0o00000;
+        loop {
+            val ^= 0o01771;
+            dsky.dsky_tx
+                .send(super::generate_yaagc_packet(0o0163, val))
+                .unwrap();
+            std::thread::sleep(std::time::Duration::new(1, 0));
+        }
+    }
+
+    #[test]
+    fn test_dsky_display_yaagc() {
+        let mut dsky = super::DskyDisplay::new();
+
+        for upper_digit_seg in AGC_SEG_TABLE.iter() {
+            for lower_digit_seg in AGC_SEG_TABLE.iter() {
+                let value: u16 =
+                    (11 << 11) | *lower_digit_seg as u16 | ((*upper_digit_seg as u16) << 5);
+                dsky.set_channel_dsky_value(value);
+
+                let value: u16 =
+                    (10 << 11) | *lower_digit_seg as u16 | ((*upper_digit_seg as u16) << 5);
+                dsky.set_channel_dsky_value(value);
+
+                let value: u16 =
+                    (9 << 11) | *lower_digit_seg as u16 | ((*upper_digit_seg as u16) << 5);
+                dsky.set_channel_dsky_value(value);
+
+                dsky_display_digit_index(&mut dsky, 8, upper_digit_seg, &0);
+                dsky_display_digit_index(&mut dsky, 7, lower_digit_seg, upper_digit_seg);
+                dsky_display_digit_index(&mut dsky, 6, lower_digit_seg, upper_digit_seg);
+                dsky_display_digit_index(&mut dsky, 5, lower_digit_seg, upper_digit_seg);
+                dsky_display_digit_index(&mut dsky, 4, lower_digit_seg, upper_digit_seg);
+                dsky_display_digit_index(&mut dsky, 3, lower_digit_seg, upper_digit_seg);
+                dsky_display_digit_index(&mut dsky, 2, lower_digit_seg, upper_digit_seg);
+                dsky_display_digit_index(&mut dsky, 1, lower_digit_seg, upper_digit_seg);
+
+                let dur = std::time::Duration::new(0, 100000000);
+                std::thread::sleep(dur);
+            }
+        }
+    }
+}

--- a/ragc-vagc/src/lib.rs
+++ b/ragc-vagc/src/lib.rs
@@ -1,0 +1,44 @@
+pub mod dsky;
+pub mod downrupt;
+
+fn generate_yaagc_packet(channel: usize, value: u16) -> [u8; 4] {
+    [
+        0x0 | ((channel >> 3) & 0x1F) as u8,
+        0x40 | ((channel & 0x7) << 3) as u8 | ((value >> 12) & 0x7) as u8,
+        0x80 | ((value >> 6) & 0x3F) as u8,
+        0xC0 | (value & 0x3F) as u8,
+    ]
+}
+
+fn parse_yaagc_packet(msg: [u8; 4]) -> Option<(u16, u16)> {
+    let a;
+    let b;
+    let c;
+    let d;
+
+    match msg.len() {
+        4 => {
+            a = *msg.get(0).unwrap();
+            b = *msg.get(1).unwrap();
+            c = *msg.get(2).unwrap();
+            d = *msg.get(3).unwrap();
+        }
+        5 => {
+            a = *msg.get(0).unwrap();
+            b = *msg.get(1).unwrap();
+            c = *msg.get(2).unwrap();
+            d = *msg.get(3).unwrap();
+        }
+        _ => {
+            return None;
+        }
+    }
+
+    if a & 0xC0 != 0x00 || b & 0xC0 != 0x40 || c & 0xC0 != 0x80 || d & 0xC0 != 0xC0 {
+        return None;
+    }
+
+    let value: u16 = ((b as u16) & 0x7) << 12 | ((c as u16) & 0x3F) << 6 | ((d & 0x3F) as u16);
+    let channel: u16 = ((a as u16) & 0x3F) << 3 | ((b as u16) >> 3 & 0x7);
+    Some((channel, value))
+}

--- a/ragc/Cargo.toml
+++ b/ragc/Cargo.toml
@@ -14,3 +14,4 @@ env_logger = "0.8.4"
 crossbeam-channel = "0.5"
 ragc-core = { path = "../ragc-core" }
 ragc-ropes = { path = "../ragc-ropes" }
+ragc-vagc = { path = "../ragc-vagc" }

--- a/ragc/src/main.rs
+++ b/ragc/src/main.rs
@@ -7,6 +7,7 @@ use log::error;
 
 use ragc_core::{cpu, mem};
 use ragc_ropes;
+use ragc_vagc;
 
 pub const ROM_BANKS_NUM: usize = 36;
 pub const ROM_BANK_NUM_WORDS: usize = 1024;
@@ -128,7 +129,10 @@ fn main() {
     let mut q1 = heapless::spsc::Queue::new();
     let (rupt_tx, _rupt_rx) = q1.split();
 
-    let mm = mem::AgcMemoryMap::new(&rope, rupt_tx);
+    let mut dsky = ragc_vagc::dsky::DskyDisplay::new();
+    let mut downrupt = ragc_vagc::downrupt::DownruptPeriph::new();
+
+    let mm = mem::AgcMemoryMap::new(&rope, &mut downrupt, &mut dsky, rupt_tx);
     let mut _cpu = cpu::AgcCpu::new(mm);
 
     _cpu.reset();


### PR DESCRIPTION
The following PR implements `ragc-core` into a `nostd` package.

The remaining std features being used were within the downrupt and DSKY peripherals. These peripherals implemented the VirtualAGC protocol. This code was pulled into it's own package for `std` Rust packages and applications.

The `ragc-core` API was updated to pass in such peripherals to allow for other DKSY/downrupt implementations (e.g. - Embedded applications).