### PR TITLE
Consolidate constants into one location

### DIFF
--- a/ragc-core/src/consts.rs
+++ b/ragc-core/src/consts.rs
@@ -38,13 +38,6 @@ pub mod io {
     pub const CHANNEL_CHAN35: usize = 0o35; // DOWNLIST WORD2
 }
 
-pub mod edit {
-    pub const SG_CYR: usize = 0o20;
-    pub const SG_SR: usize = 0o21;
-    pub const SG_CYL: usize = 0o22;
-    pub const SG_EDOP: usize = 0o23;
-}
-
 pub mod cpu {
     pub const REG_A: usize = 0x0;
     pub const REG_L: usize = 0x1; // Original Name
@@ -88,4 +81,46 @@ pub mod cpu {
     pub const TCMONITOR_COUNT: u32 = 15000000 / 11700;
 
     pub const RUPT_LOCK_COUNT: i32 = 300000000 / 11700;
+}
+
+pub mod edit {
+    pub const SG_CYR: usize = 0o20;
+    pub const SG_SR: usize = 0o21;
+    pub const SG_CYL: usize = 0o22;
+    pub const SG_EDOP: usize = 0o23;
+}
+
+pub mod timer {
+    pub const MM_TIME2: usize = 0o24;
+    pub const MM_TIME1: usize = 0o25;
+    pub const MM_TIME3: usize = 0o26;
+    pub const MM_TIME4: usize = 0o27;
+    pub const MM_TIME5: usize = 0o30;
+    pub const MM_TIME6: usize = 0o31;
+}
+
+pub mod special {
+    pub const SG_CDUX: usize = 0o32;
+    pub const SG_CDUY: usize = 0o33;
+    pub const SG_CDUZ: usize = 0o34;
+    pub const SG_OPTY: usize = 0o35;
+    pub const SG_OPTX: usize = 0o36;
+    pub const SG_PIPAX: usize = 0o37;
+    pub const SG_PIPAY: usize = 0o40;
+    pub const SG_PIPAZ: usize = 0o41;
+    pub const SG_RCHP: usize = 0o42;
+    pub const SG_RCHY: usize = 0o43;
+    pub const SG_RCHR: usize = 0o44;
+    pub const SG_INLINK: usize = 0o45;
+    pub const SG_RNRAD: usize = 0o46;
+    pub const SG_GYROCTR: usize = 0o47;
+    pub const SG_CDUXCMD: usize = 0o50;
+    pub const SG_CDUYCMD: usize = 0o51;
+    pub const SG_CDUZCMD: usize = 0o52;
+    pub const SG_OPTYCMD: usize = 0o53;
+    pub const SG_OPTXCMD: usize = 0o54;
+    pub const SG_THRUST: usize = 0o55; // LM only
+    pub const SG_LEMONM: usize = 0o56; // LM only
+    pub const SG_OUTLINK: usize = 0o57;
+    pub const SG_ALTM: usize = 0o60; // LM Only
 }

--- a/ragc-core/src/consts.rs
+++ b/ragc-core/src/consts.rs
@@ -12,6 +12,19 @@ pub const ROM_NUM_BANKS: usize = 36;
 /* Number of words within a given FIXED memory bank */
 pub const ROM_BANK_NUM_WORDS: usize = 1024;
 
+/* Constants to define the memory map addresses */
+pub mod memmap {
+    // 3072 words of ERASABLE assessable memory
+    pub const AGC_MM_ERASABLE_SIZE: usize = 0x400;
+    // 3072 words of FIXED assessable memory
+    pub const AGC_MM_FIXED_SIZE: usize = 0xC00;
+
+
+    pub const AGC_MM_ERASABLE_START: usize = 0o61;
+    pub const AGC_MM_ERASABLE_END: usize = AGC_MM_ERASABLE_SIZE - 1;
+    pub const AGC_MM_FIXED_START: usize = AGC_MM_ERASABLE_SIZE;
+    pub const AGC_MM_FIXED_END: usize = AGC_MM_FIXED_START + AGC_MM_FIXED_SIZE - 1;
+}
 
 pub mod io {
     pub const CHANNEL_L: usize = 0o01;

--- a/ragc-core/src/consts.rs
+++ b/ragc-core/src/consts.rs
@@ -11,3 +11,81 @@ pub const ROM_NUM_BANKS: usize = 36;
 
 /* Number of words within a given FIXED memory bank */
 pub const ROM_BANK_NUM_WORDS: usize = 1024;
+
+
+pub mod io {
+    pub const CHANNEL_L: usize = 0o01;
+    pub const CHANNEL_Q: usize = 0o02;
+    pub const CHANNEL_HISCALAR: usize = 0o03;
+    pub const CHANNEL_LOSCALAR: usize = 0o04;
+    pub const CHANNEL_PYJETS: usize = 0o05;
+    pub const CHANNEL_ROLLJETS: usize = 0o06;
+    pub const CHANNEL_SUPERBNK: usize = 0o07; // Only bits[7:5] and only 0XX or 100 are
+                                              // valid
+    pub const CHANNEL_DSKY: usize = 0o10;
+    pub const CHANNEL_DSALMOUT: usize = 0o11;
+    pub const CHANNEL_CHAN12: usize = 0o12;
+    pub const CHANNEL_CHAN13: usize = 0o13;
+    pub const CHANNEL_CHAN14: usize = 0o14;
+    pub const CHANNEL_MNKEYIN: usize = 0o15;
+    pub const CHANNEL_NAVKEYIN: usize = 0o16;
+
+    pub const CHANNEL_CHAN30: usize = 0o30;
+    pub const CHANNEL_CHAN31: usize = 0o31;
+    pub const CHANNEL_CHAN32: usize = 0o32;
+    pub const CHANNEL_CHAN33: usize = 0o33;
+    pub const CHANNEL_CHAN34: usize = 0o34; // DOWNLIST WORD1
+    pub const CHANNEL_CHAN35: usize = 0o35; // DOWNLIST WORD2
+}
+
+pub mod edit {
+    pub const SG_CYR: usize = 0o20;
+    pub const SG_SR: usize = 0o21;
+    pub const SG_CYL: usize = 0o22;
+    pub const SG_EDOP: usize = 0o23;
+}
+
+pub mod cpu {
+    pub const REG_A: usize = 0x0;
+    pub const REG_L: usize = 0x1; // Original Name
+    pub const REG_B: usize = 0x1;
+    pub const REG_Q: usize = 0x02; // Original Name
+    pub const REG_LR: usize = 0x2;
+    pub const REG_EB: usize = 0x3;
+    pub const REG_FB: usize = 0x4;
+    pub const REG_Z: usize = 0x05;
+    pub const REG_PC: usize = 0x05;
+    pub const REG_BB: usize = 0x6;
+    pub const REG_ZERO: usize = 0x7;
+    pub const REG_A_SHADOW: usize = 0x8;
+    pub const REG_B_SHADOW: usize = 0x9;
+    pub const REG_LR_SHADOW: usize = 0xA;
+    pub const REG_EB_SHADOW: usize = 0xB;
+    pub const REG_FB_SHADOW: usize = 0xC;
+    pub const REG_PC_SHADOW: usize = 0xD;
+    pub const REG_BB_SHADOW: usize = 0xE;
+
+    pub const REG_IR: usize = 0xF;
+    pub const REG_MAX: usize = 0x10;
+
+    pub const RUPT_RESET: u8 = 0x0;
+    pub const RUPT_TIME6: u8 = 0x1;
+    pub const RUPT_TIME5: u8 = 0x2;
+    pub const RUPT_TIME3: u8 = 0x3;
+    pub const RUPT_TIME4: u8 = 0x4;
+    pub const RUPT_KEY1: u8 = 0x5;
+    pub const RUPT_KEY2: u8 = 0x6;
+    pub const RUPT_UPRUPT: u8 = 0x7;
+    pub const RUPT_DOWNRUPT: u8 = 0x8;
+    pub const RUPT_RADAR: u8 = 0x9;
+    pub const RUPT_HANDRUPT: u8 = 0xA;
+
+    pub const NIGHTWATCH_TIME: u32 = 1920000000 / 11700;
+
+    // Each TC/TCF is 1 cycle, so we just need to have to know how many cycles it
+    // takes for 15ms and thats how many TC/TCF instructions we have to see in
+    // sequence to reset.
+    pub const TCMONITOR_COUNT: u32 = 15000000 / 11700;
+
+    pub const RUPT_LOCK_COUNT: i32 = 300000000 / 11700;
+}

--- a/ragc-core/src/consts.rs
+++ b/ragc-core/src/consts.rs
@@ -1,0 +1,13 @@
+
+
+/* Number of Erasable Banks within a given AGC computer */
+pub const RAM_NUM_BANKS: usize = 8;
+
+/* Number of words within a given Erasable memory bank */
+pub const RAM_BANK_NUM_WORDS: usize = 256;
+
+/* Number of Fixed Banks within a given AGC computer */
+pub const ROM_NUM_BANKS: usize = 36;
+
+/* Number of words within a given FIXED memory bank */
+pub const ROM_BANK_NUM_WORDS: usize = 1024;

--- a/ragc-core/src/cpu.rs
+++ b/ragc-core/src/cpu.rs
@@ -5,49 +5,7 @@ use crate::instr::{AgcArith, AgcControlFlow, AgcInterrupt, AgcIo, AgcLoadStore, 
 use crate::instr::{AgcInst, AgcMnem};
 use crate::mem::AgcMemoryMap;
 use crate::utils::{overflow_correction, s15_add, sign_extend};
-
-pub const REG_A: usize = 0x0;
-pub const REG_L: usize = 0x1; // Original Name
-pub const _REG_B: usize = 0x1;
-pub const REG_Q: usize = 0x02; // Original Name
-pub const REG_LR: usize = 0x2;
-pub const REG_EB: usize = 0x3;
-pub const REG_FB: usize = 0x4;
-pub const REG_Z: usize = 0x05;
-pub const REG_PC: usize = 0x05;
-pub const REG_BB: usize = 0x6;
-pub const REG_ZERO: usize = 0x7;
-pub const _REG_A_SHADOW: usize = 0x8;
-pub const _REG_B_SHADOW: usize = 0x9;
-pub const _REG_LR_SHADOW: usize = 0xA;
-pub const _REG_EB_SHADOW: usize = 0xB;
-pub const _REG_FB_SHADOW: usize = 0xC;
-pub const REG_PC_SHADOW: usize = 0xD;
-pub const _REG_BB_SHADOW: usize = 0xE;
-
-pub const REG_IR: usize = 0xF;
-pub const _REG_MAX: usize = 0x10;
-
-pub const _RUPT_RESET: u8 = 0x0;
-pub const RUPT_TIME6: u8 = 0x1;
-pub const RUPT_TIME5: u8 = 0x2;
-pub const RUPT_TIME3: u8 = 0x3;
-pub const RUPT_TIME4: u8 = 0x4;
-pub const RUPT_KEY1: u8 = 0x5;
-pub const _RUPT_KEY2: u8 = 0x6;
-pub const _RUPT_UPRUPT: u8 = 0x7;
-pub const RUPT_DOWNRUPT: u8 = 0x8;
-pub const _RUPT_RADAR: u8 = 0x9;
-pub const _RUPT_HANDRUPT: u8 = 0xA;
-
-pub const NIGHTWATCH_TIME: u32 = 1920000000 / 11700;
-
-// Each TC/TCF is 1 cycle, so we just need to have to know how many cycles it
-// takes for 15ms and thats how many TC/TCF instructions we have to see in
-// sequence to reset.
-pub const TCMONITOR_COUNT: u32 = 15000000 / 11700;
-
-pub const RUPT_LOCK_COUNT: i32 = 300000000 / 11700;
+use crate::consts::cpu::*;
 
 #[derive(Debug)]
 #[allow(dead_code)]

--- a/ragc-core/src/instr/arith.rs
+++ b/ragc-core/src/instr/arith.rs
@@ -1,5 +1,6 @@
 use super::AgcInst;
-use crate::cpu::*;
+use crate::cpu::AgcCpu;
+use crate::consts::cpu::*;
 
 use log::{debug, error, trace};
 

--- a/ragc-core/src/instr/cf.rs
+++ b/ragc-core/src/instr/cf.rs
@@ -1,5 +1,6 @@
 use super::AgcInst;
-use crate::cpu::*;
+use crate::cpu::AgcCpu;
+use crate::consts::cpu::*;
 
 use log::{error, warn};
 

--- a/ragc-core/src/instr/intrpt.rs
+++ b/ragc-core/src/instr/intrpt.rs
@@ -1,5 +1,6 @@
 use super::AgcInst;
-use crate::cpu::*;
+use crate::cpu::AgcCpu;
+use crate::consts::cpu::*;
 
 pub trait AgcInterrupt {
     fn inhint(&mut self, inst: &AgcInst) -> u16;

--- a/ragc-core/src/instr/io.rs
+++ b/ragc-core/src/instr/io.rs
@@ -1,6 +1,7 @@
 use super::AgcInst;
-use crate::cpu::*;
+use crate::cpu::AgcCpu;
 use crate::utils::{overflow_correction, sign_extend};
+use crate::consts::cpu::*;
 
 use log::debug;
 

--- a/ragc-core/src/instr/ldst.rs
+++ b/ragc-core/src/instr/ldst.rs
@@ -1,5 +1,6 @@
 use super::AgcInst;
-use crate::cpu::*;
+use crate::cpu::AgcCpu;
+use crate::consts::cpu::*;
 use crate::utils;
 
 use log::debug;

--- a/ragc-core/src/instr/logic.rs
+++ b/ragc-core/src/instr/logic.rs
@@ -1,6 +1,6 @@
 use super::AgcInst;
-use crate::cpu;
-use crate::cpu::*;
+use crate::cpu::AgcCpu;
+use crate::consts::cpu::*;
 
 pub trait AgcLogic {
     fn mask(&mut self, inst: &AgcInst) -> u16;
@@ -28,7 +28,7 @@ impl <'a>AgcLogic for AgcCpu<'a> {
     fn mask(&mut self, inst: &AgcInst) -> u16 {
         let k = inst.get_kaddr();
         match k {
-            cpu::REG_A | cpu::REG_Q => {
+            REG_A | REG_Q => {
                 let mut val = self.read_s16(k);
                 val = self.read_s16(REG_A) & val;
                 self.write_s16(REG_A, val);

--- a/ragc-core/src/lib.rs
+++ b/ragc-core/src/lib.rs
@@ -5,3 +5,4 @@ pub mod disasm;
 pub mod instr;
 pub mod mem;
 pub mod utils;
+pub mod consts;

--- a/ragc-core/src/mem/edit.rs
+++ b/ragc-core/src/mem/edit.rs
@@ -1,10 +1,6 @@
 use crate::mem::AgcMemType;
+use crate::consts::edit::{*};
 use log::{error, trace};
-
-const SG_CYR: usize = 0o20;
-const SG_SR: usize = 0o21;
-const SG_CYL: usize = 0o22;
-const SG_EDOP: usize = 0o23;
 
 #[derive(Clone)]
 pub struct AgcEditRegs {

--- a/ragc-core/src/mem/io.rs
+++ b/ragc-core/src/mem/io.rs
@@ -1,31 +1,9 @@
 use super::periph::engines::LmEngines;
 use super::periph::AgcIoPeriph;
 use crate::{utils::Option as Option};
+use crate::consts::io;
 
 use log::{debug, error, warn};
-
-pub const CHANNEL_L: usize = 0o01;
-pub const CHANNEL_Q: usize = 0o02;
-pub const CHANNEL_HISCALAR: usize = 0o03;
-pub const CHANNEL_LOSCALAR: usize = 0o04;
-pub const CHANNEL_PYJETS: usize = 0o05;
-pub const CHANNEL_ROLLJETS: usize = 0o06;
-pub const CHANNEL_SUPERBNK: usize = 0o07; // Only bits[7:5] and only 0XX or 100 are
-                                          // valid
-pub const CHANNEL_DSKY: usize = 0o10;
-pub const CHANNEL_DSALMOUT: usize = 0o11;
-pub const CHANNEL_CHAN12: usize = 0o12;
-pub const CHANNEL_CHAN13: usize = 0o13;
-pub const CHANNEL_CHAN14: usize = 0o14;
-pub const CHANNEL_MNKEYIN: usize = 0o15;
-pub const CHANNEL_NAVKEYIN: usize = 0o16;
-
-pub const CHANNEL_CHAN30: usize = 0o30;
-pub const CHANNEL_CHAN31: usize = 0o31;
-pub const CHANNEL_CHAN32: usize = 0o32;
-pub const CHANNEL_CHAN33: usize = 0o33;
-pub const CHANNEL_CHAN34: usize = 0o34; // DOWNLIST WORD1
-pub const CHANNEL_CHAN35: usize = 0o35; // DOWNLIST WORD2
 
 pub struct AgcIoSpace<'a> {
     io_mem: [u16; 256],
@@ -109,19 +87,19 @@ impl<'a> AgcIoSpace<'a> {
         match channel_idx {
             // # CHANNEL 1     IDENTICAL TO COMPUTER REGISTER L (0001)
             // # CHANNEL 2     IDENTICAL TO COMPUTER REGISTER Q (0002)
-            //CHANNEL_L => { self.parent.read(crate::cpu::REG_L) }
-            //CHANNEL_Q => { self.parent.read(crate::cpu::REG_Q) }
+            //io::CHANNEL_L => { self.parent.read(crate::cpu::REG_L) }
+            //io::CHANNEL_Q => { self.parent.read(crate::cpu::REG_Q) }
 
             // # CHANNEL 3     HISCALAR; INPUT CHANNEL; MOST SIGNIFICANT 14 BITS FROM 33 STAGE BINARY COUNTER. SCALE
             // #               FACTOR IS B23 IN CSEC, SO MAX VALUE ABOUT 23.3 HOURS AND LEAST SIGNIFICANT BIT 5.12 SECS.
             // # CHANNEL 4     LOSCALAR; INPUT CHANNEL; NEXT MOST SIGNIFICANT 14 BITS FROM THE 33 STAGE BINARY COUNTER
             // #               ASSOCIATED WITH CHANNEL 3. SCALE FACTOR IS B9 IN  CSEC. SO MAX VAL IS 5.12 SEC AND LEAST
             // #               SIGNIFICANT BIT IS 1/3200 SEC. SCALE FACTOR OF D.P. WORD WITH CHANNEL 3 IS B23 CSEC.
-            CHANNEL_LOSCALAR | CHANNEL_HISCALAR => 0,
+            io::CHANNEL_LOSCALAR | io::CHANNEL_HISCALAR => 0,
 
             // # CHANNEL 7     SUPERBNK; OUTPUT CHANNEL; NOT RESET BY RESTART;   FIXED EXTENSION BITS USED TO SELECT THE
             // #               APPROPRIATE FIXED MEMORY BANK IF FBANK IS 30 OCTAL OR MORE. USES BITS 5-7.
-            CHANNEL_SUPERBNK => self.io_mem[channel_idx] & 0o00160,
+            io::CHANNEL_SUPERBNK => self.io_mem[channel_idx] & 0o00160,
 
             // # CHANNEL 5     PYJETS; OUTPUT CHANNEL; PITCH RCS JET CONTROL.   (REACTION CONTROL SYSTEM) USES BITS 1-8.
             //
@@ -130,9 +108,9 @@ impl<'a> AgcIoSpace<'a> {
             // # CHANNEL 10    OUTO; OUTPUT CHANNEL; REGISTER USED TO TRANSMIT  LATCHING-RELAY DRIVING INFORMATION FOR
             // #               THE DISPLAY SYSTEM. BITS 15-12 ARE SET TO THE ROW NUMBER (1-14 OCTAL) OF THE RELAY TO BE
             // #               CHANGED AND BITS 11-1 CONTAIN THE REQUIRED SETTINGS FOR THE RELAYS IN THE ROW.
-            CHANNEL_PYJETS | CHANNEL_ROLLJETS => self.io_mem[channel_idx],
+            io::CHANNEL_PYJETS | io::CHANNEL_ROLLJETS => self.io_mem[channel_idx],
 
-            CHANNEL_DSKY => {
+            io::CHANNEL_DSKY => {
                 warn!("DSKY: Reading from DSKY value. which is weird");
                 0
             }
@@ -155,7 +133,7 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 13          ENGINE ON
             // #               BIT 14          ENGINE OFF
             // #               BIT 15          SPARE
-            CHANNEL_DSALMOUT => self.io_mem[CHANNEL_DSALMOUT], //self.handle_channel11_read(),
+            io::CHANNEL_DSALMOUT => self.io_mem[io::CHANNEL_DSALMOUT], //self.handle_channel11_read(),
 
             // # CHANNEL 12    CHAN12; OUTPUT CHANNEL; BITS USED TO DRIVE NAVIGATION AND SPAECRAFT HARDWARE
             //
@@ -174,7 +152,7 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 13          LR POSITION 2 COMMAND
             // #               BIT 14          ENABLE RENDESVOUS RADAR LOCK-ON;AUTO ANGLE TRACK'G
             // #               BIT 15          ISS TURN ON DELAY COMPLETE
-            CHANNEL_CHAN12 => self.io_mem[CHANNEL_CHAN12],
+            io::CHANNEL_CHAN12 => self.io_mem[io::CHANNEL_CHAN12],
 
             // ## Page 56
             // # CHANNEL 13    CHAN13; OUTPUT CHANNEL
@@ -194,7 +172,7 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 13          RESET TRAP 31-B         ALWAYS APPEAR TO BE SET TO 0
             // #               BIT 14          RESET TRAP 32           ALWAYS APPEAR TO BE SET TO 0
             // #               BIT 15          ENABLE T6 RUPT
-            CHANNEL_CHAN13 => self.io_mem[CHANNEL_CHAN13] & 0x47CF,
+            io::CHANNEL_CHAN13 => self.io_mem[io::CHANNEL_CHAN13] & 0x47CF,
 
             // # CHANNEL 14    CHAN14; OUTPUT CHANNEL; USED TO CONTROL COMPUTER COUNTER CELLS (CDU,GYRO,SPACECRAFT FUNC.
             //
@@ -214,11 +192,11 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 13          DRIVE CDU Z
             // #               BIT 14          DRIVE CDU Y
             // #               BIT 15          DRIVE CDU X
-            CHANNEL_CHAN14 => self.io_mem[CHANNEL_CHAN14],
+            io::CHANNEL_CHAN14 => self.io_mem[io::CHANNEL_CHAN14],
 
             // # CHANNEL 15    MNKEYIN; INPUT CHANNEL;KEY CODE INPUT FROM KEYBOARD OF DSKY, SENSED BY PROGRAM WHEN
             // #               PROGRAM INTERRUPT #5 IS RECEIVED. USES BITS 5-1
-            CHANNEL_MNKEYIN => {
+            io::CHANNEL_MNKEYIN => {
                 match &self.dsky {
                     Option::Some(x) => {
                         x.read(channel_idx)
@@ -236,7 +214,7 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 5           OPTICS MARK REJECT SIGNAL
             // #               BIT 6           DESCENT+ ; CREW DESIRED SLOWING RATE OF DESCENT
             // #               BIT 7           DESCENT- ; CREW DESIRED SPEEDING UP RATE OF D'CENT
-            CHANNEL_NAVKEYIN => 0,
+            io::CHANNEL_NAVKEYIN => 0,
 
             // # NOTE: ALL BITS IN CHANNELS 30-33 ARE INVERTED AS SENSED BY THE  PROGRAM, SO THAT A VALUE OF ZERO MEANS
             // # THAT THE INDICATED SIGNAL IS PRESENT.
@@ -259,7 +237,7 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 13          IMU FAIL (MALFUNCTION OF IMU STABILIZATION LOOPS)
             // #               BIT 14          ISS TURN ON REQUESTED
             // #               BIT 15          TEMPERATURE OF STABLE MEMBER WITHIN DESIGN LIMITS
-            CHANNEL_CHAN30 => self.handle_channel30_read(),
+            io::CHANNEL_CHAN30 => self.handle_channel30_read(),
 
             // # CHANNEL 31    INPUT CHANNEL; BITS ASSOCIATED WITH THE ATTITUDE CONTROLLER, TRANSLATIONAL CONTROLLER,
             // #               AND SPACECRAFT ATTITUDE CONTROL; USED BY RCS DAP
@@ -282,7 +260,7 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 13          ATTITUDE HOLD MODE ON SCS MODE CONTROL SWITCH
             // #               BIT 14          AUTO STABILIZATION OF ATTITUDE ON SCS MODE SWITCH
             // #               BIT 15          ATTITUDE CONTROL OUT OF DETENT (RHC NOT IN NEUTRAL
-            CHANNEL_CHAN31 => 0o77777,
+            io::CHANNEL_CHAN31 => 0o77777,
 
             // # CHANNEL 32    INPUT CHANNEL.
             //
@@ -297,7 +275,7 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 9              DESCENT ENGINE GIMBALS DISABLED BY CREW
             // #               BIT 10             APPARENT DESCENT ENGINE GIMBAL FAILURE
             // #               BIT 14             INDICATES PROCEED KEY IS DEPRESSED
-            CHANNEL_CHAN32 => {
+            io::CHANNEL_CHAN32 => {
                 let val = match &self.dsky {
                     Option::Some(x) => {
                         x.read(channel_idx)
@@ -327,11 +305,11 @@ impl<'a> AgcIoSpace<'a> {
             // #               BIT 13          PIPA FAIL
             // #               BIT 14          WARNING OF REPEATED ALARMS: RESTART,COUNTER FAIL, VOLTAGE FAIL,AND SCALAR DOUBLE.
             // #               BIT 15          LGC OSCILLATOR STOPPED
-            CHANNEL_CHAN33 => 0o77777,
+            io::CHANNEL_CHAN33 => 0o77777,
 
             // # CHANNEL 34    DNT M1; OUTPUT CHANNEL; DOWNLINK 1  FIRST OF TWO WORDS SERIALIZATION.
             // # CHANNEL 35    DNT M2; OUTPUT CHANNEL DOWNLINK 2 SOCOND OF TWO   WORDS SERIALIZATION.
-            CHANNEL_CHAN34 | CHANNEL_CHAN35 => {
+            io::CHANNEL_CHAN34 | io::CHANNEL_CHAN35 => {
                 match &self.downrupt {
                     Option::Some(x) => {
                         x.read(channel_idx)
@@ -376,14 +354,14 @@ impl<'a> AgcIoSpace<'a> {
         }
 
         match channel_idx {
-            CHANNEL_DSALMOUT => {
-                self.io_mem[CHANNEL_DSALMOUT] = val; //val & 0x33FF;
+            io::CHANNEL_DSALMOUT => {
+                self.io_mem[io::CHANNEL_DSALMOUT] = val; //val & 0x33FF;
             }
-            CHANNEL_SUPERBNK => self.io_mem[channel_idx] = val & 0o00160,
-            CHANNEL_CHAN13 => {
-                self.io_mem[CHANNEL_CHAN13] = val;
+            io::CHANNEL_SUPERBNK => self.io_mem[channel_idx] = val & 0o00160,
+            io::CHANNEL_CHAN13 => {
+                self.io_mem[io::CHANNEL_CHAN13] = val;
             }
-            CHANNEL_CHAN32 => {
+            io::CHANNEL_CHAN32 => {
                 warn!("Attempting to write to IO CHAN32 which is only an input");
             }
             _ => {

--- a/ragc-core/src/mem/mod.rs
+++ b/ragc-core/src/mem/mod.rs
@@ -19,14 +19,7 @@ use log::{error, trace};
 use self::periph::AgcIoPeriph;
 
 use crate::consts;
-
-const _AGC_MM_RAMSIZE: usize = 1024;
-const _AGC_MM_ROMSIZE: usize = 3072;
-
-const AGC_MM_RAM_START: usize = 0o61;
-const AGC_MM_RAM_END: usize = 1023;
-const AGC_MM_ROM_START: usize = 1024;
-const AGC_MM_ROM_END: usize = 4096;
+use crate::consts::memmap;
 
 // ============================================================================
 // Trait Declarations
@@ -180,14 +173,14 @@ impl<'a> AgcMemoryMap<'a> {
             0o32..=0o60 => {
                 self.special.write(0, idx, val);
             }
-            AGC_MM_RAM_START..=AGC_MM_RAM_END => {
+            memmap::AGC_MM_ERASABLE_START..=memmap::AGC_MM_ERASABLE_END => {
                 if (idx >> 8) == 3 {
                     self.ram.write(self.regs.ebank, (idx & 0xff) as usize, val)
                 } else {
                     self.ram.write(idx >> 8, (idx & 0xff) as usize, val)
                 }
             }
-            AGC_MM_ROM_START..=AGC_MM_ROM_END => {
+            memmap::AGC_MM_FIXED_START..=memmap::AGC_MM_FIXED_END => {
                 if self.rom_debug == false {
                     error!("Writing to ROM location: {:x}", idx);
                     return;
@@ -212,14 +205,14 @@ impl<'a> AgcMemoryMap<'a> {
             0o20..=0o23 => self.edit.read(0, idx),
             0o24..=0o31 => self.timers.read(0, idx),
             0o32..=0o60 => self.special.read(0, idx),
-            AGC_MM_RAM_START..=AGC_MM_RAM_END => {
+            memmap::AGC_MM_ERASABLE_START..=memmap::AGC_MM_ERASABLE_END => {
                 if (idx >> 8) == 3 {
                     self.ram.read(self.regs.ebank, (idx & 0xff) as usize)
                 } else {
                     self.ram.read(idx >> 8, (idx & 0xff) as usize)
                 }
             }
-            AGC_MM_ROM_START..=AGC_MM_ROM_END => {
+            memmap::AGC_MM_FIXED_START..=memmap::AGC_MM_FIXED_END => {
                 if (idx >> 10) == 1 {
                     trace!("Reading from Windowed ROM: {:x} {:x}", self.regs.fbank, idx);
                     match self.regs.fbank {

--- a/ragc-core/src/mem/mod.rs
+++ b/ragc-core/src/mem/mod.rs
@@ -17,6 +17,7 @@ use heapless::spsc::Producer;
 use log::{error, trace};
 
 use self::periph::AgcIoPeriph;
+use crate::consts;
 
 const _AGC_MM_RAMSIZE: usize = 1024;
 const _AGC_MM_ROMSIZE: usize = 3072;
@@ -64,7 +65,7 @@ impl<'a> AgcMemoryMap<'a> {
         }
     }
 
-    pub fn new(program: &'a [[u16; rom::ROM_BANK_NUM_WORDS]; rom::ROM_BANKS_NUM],
+    pub fn new(program: &'a [[u16; consts::ROM_BANK_NUM_WORDS]; consts::ROM_NUM_BANKS],
                downrupt: &'a mut dyn AgcIoPeriph,
                dsky: &'a mut dyn AgcIoPeriph,
                rupt_tx: Producer<u8, 8>) -> AgcMemoryMap<'a> {

--- a/ragc-core/src/mem/mod.rs
+++ b/ragc-core/src/mem/mod.rs
@@ -17,6 +17,7 @@ use heapless::spsc::Producer;
 use log::{error, trace};
 
 use self::periph::AgcIoPeriph;
+
 use crate::consts;
 
 const _AGC_MM_RAMSIZE: usize = 1024;
@@ -102,13 +103,13 @@ impl<'a> AgcMemoryMap<'a> {
 
     pub fn write_io(&mut self, idx: usize, value: u16) {
         match idx {
-            io::CHANNEL_L => {
-                self.regs.write(0, crate::cpu::REG_L, value);
+            consts::io::CHANNEL_L => {
+                self.regs.write(0, consts::cpu::REG_L, value);
             }
-            io::CHANNEL_Q => {
-                self.regs.write(0, crate::cpu::REG_Q, value);
+            consts::io::CHANNEL_Q => {
+                self.regs.write(0, consts::cpu::REG_Q, value);
             }
-            io::CHANNEL_SUPERBNK => {
+            consts::io::CHANNEL_SUPERBNK => {
                 if value & 0x40 == 0x40 {
                     self.superbank = true;
                 } else {
@@ -116,7 +117,7 @@ impl<'a> AgcMemoryMap<'a> {
                 }
                 self.io.write(idx, value);
             }
-            io::CHANNEL_CHAN13 => {
+            consts::io::CHANNEL_CHAN13 => {
                 match (value & 0o40000) == 0o40000 {
                     true => {
                         self.timers.set_time6_enable(true);
@@ -127,11 +128,11 @@ impl<'a> AgcMemoryMap<'a> {
                 }
                 self.io.write(idx, value & 0o37777);
             }
-            io::CHANNEL_CHAN34 => {
+            consts::io::CHANNEL_CHAN34 => {
                 self.timers.set_downrupt_flags(1);
                 self.io.write(idx, value);
             }
-            io::CHANNEL_CHAN35 => {
+            consts::io::CHANNEL_CHAN35 => {
                 self.timers.set_downrupt_flags(2);
                 self.io.write(idx, value);
             }
@@ -143,17 +144,17 @@ impl<'a> AgcMemoryMap<'a> {
 
     pub fn read_io(&mut self, idx: usize) -> u16 {
         match idx {
-            io::CHANNEL_L => self.regs.read(0, crate::cpu::REG_L),
-            io::CHANNEL_Q => self.regs.read(0, crate::cpu::REG_Q),
-            io::CHANNEL_HISCALAR => {
+            consts::io::CHANNEL_L => self.regs.read(0, consts::cpu::REG_L),
+            consts::io::CHANNEL_Q => self.regs.read(0, consts::cpu::REG_Q),
+            consts::io::CHANNEL_HISCALAR => {
                 let result = self.timers.read_scalar();
                 ((result >> 14) & 0o37777) as u16
             }
-            io::CHANNEL_LOSCALAR => {
+            consts::io::CHANNEL_LOSCALAR => {
                 let result = self.timers.read_scalar();
                 (result & 0o37777) as u16
             }
-            io::CHANNEL_CHAN13 => {
+            consts::io::CHANNEL_CHAN13 => {
                 let mut res = self.io.read(idx);
                 if self.timers.get_time6_enable() {
                     res |= 0o40000;

--- a/ragc-core/src/mem/ram.rs
+++ b/ragc-core/src/mem/ram.rs
@@ -1,4 +1,3 @@
-use crate::cpu;
 use crate::mem::AgcMemType;
 use crate::consts;
 use log::trace;

--- a/ragc-core/src/mem/ram.rs
+++ b/ragc-core/src/mem/ram.rs
@@ -1,16 +1,11 @@
 use crate::cpu;
 use crate::mem::AgcMemType;
+use crate::consts;
 use log::trace;
-
-/* Number of Banks within a given AGC computer */
-pub const RAM_NUM_BANKS: usize = 8;
-
-/* Number of Words within a given RAM Bank */
-const RAM_BANK_SIZE: usize = 256;
 
 #[derive(Clone)]
 pub struct AgcRam {
-    banks: [[u16; RAM_BANK_SIZE]; RAM_NUM_BANKS],
+    banks: [[u16; consts::RAM_BANK_NUM_WORDS]; consts::RAM_NUM_BANKS],
     #[cfg(feature = "std")]
     enable_savestate: bool,
 }
@@ -22,7 +17,7 @@ impl AgcRam {
     ///
     pub fn new() -> AgcRam {
         AgcRam {
-            banks: [[0; RAM_BANK_SIZE]; RAM_NUM_BANKS],
+            banks: [[0; consts::RAM_BANK_NUM_WORDS]; consts::RAM_NUM_BANKS],
             #[cfg(feature = "std")]
             enable_savestate: false,
         }
@@ -35,7 +30,7 @@ impl AgcRam {
     ///
     #[allow(dead_code)]
     pub fn reset(&mut self) {
-        self.banks = [[0; RAM_BANK_SIZE]; RAM_NUM_BANKS];
+        self.banks = [[0; consts::RAM_BANK_NUM_WORDS]; consts::RAM_NUM_BANKS];
     }
 }
 
@@ -159,6 +154,7 @@ mod ramstd {
 #[cfg(test)]
 mod agc_ram_tests {
     use super::*;
+    use crate::consts;
 
     #[test]
     fn reset_test() {
@@ -166,16 +162,16 @@ mod agc_ram_tests {
 
         // Load with Random Value to ensure reset will do what it should be
         // doing.
-        for i in 0..RAM_NUM_BANKS {
-            for j in 0..RAM_BANK_SIZE {
+        for i in 0..consts::RAM_NUM_BANKS {
+            for j in 0..consts::RAM_BANK_NUM_WORDS {
                 ram.banks[i][j] = 0xAA55;
             }
         }
 
         // Reset
         ram.reset();
-        for i in 0..RAM_NUM_BANKS {
-            for j in 0..RAM_BANK_SIZE {
+        for i in 0..consts::RAM_NUM_BANKS {
+            for j in 0..consts::RAM_BANK_NUM_WORDS {
                 assert_eq!(0, ram.banks[i][j]);
             }
         }
@@ -185,8 +181,8 @@ mod agc_ram_tests {
     fn test_read_s15_locations() {
         let mut ram = AgcRam::new();
 
-        for i in 0..RAM_NUM_BANKS {
-            for j in 0..RAM_BANK_SIZE {
+        for i in 0..consts::RAM_NUM_BANKS {
+            for j in 0..consts::RAM_BANK_NUM_WORDS {
                 ram.reset();
                 ram.banks[i][j] = 0x55AA;
                 assert_eq!(
@@ -219,8 +215,8 @@ mod agc_ram_tests {
         }
 
         // Test 15-Bit
-        for i in 0..RAM_NUM_BANKS {
-            for j in 0..RAM_BANK_SIZE {
+        for i in 0..consts::RAM_NUM_BANKS {
+            for j in 0..consts::RAM_BANK_NUM_WORDS {
                 if i == 0 && regs_16bit.contains(&j) {
                     continue;
                 }
@@ -242,8 +238,8 @@ mod agc_ram_tests {
     fn test_write_s15_locations() {
         let mut ram = AgcRam::new();
 
-        for i in 0..RAM_NUM_BANKS {
-            for j in 0..RAM_BANK_SIZE {
+        for i in 0..consts::RAM_NUM_BANKS {
+            for j in 0..consts::RAM_BANK_NUM_WORDS {
                 ram.reset();
                 ram.write(i, j, 0x55AA);
                 assert_eq!(

--- a/ragc-core/src/mem/ram.rs
+++ b/ragc-core/src/mem/ram.rs
@@ -52,9 +52,9 @@ impl AgcMemType for AgcRam {
     ///    and `bank_offset`
     ///
     fn read(&self, bank_idx: usize, bank_offset: usize) -> u16 {
-        let res = if bank_idx == 0x0 && bank_offset == cpu::REG_A {
+        let res = if bank_idx == 0x0 && bank_offset == consts::cpu::REG_A {
             self.banks[bank_idx][bank_offset]
-        } else if bank_idx == 0x0 && bank_offset == cpu::REG_Q {
+        } else if bank_idx == 0x0 && bank_offset == consts::cpu::REG_Q {
             self.banks[bank_idx][bank_offset]
         } else {
             self.banks[bank_idx][bank_offset] & 0x7FFF
@@ -86,9 +86,9 @@ impl AgcMemType for AgcRam {
             bank_offset,
             value
         );
-        if bank_idx == 0x0 && bank_offset == cpu::REG_A {
+        if bank_idx == 0x0 && bank_offset == consts::cpu::REG_A {
             self.banks[bank_idx][bank_offset] = value;
-        } else if bank_idx == 0x0 && bank_offset == cpu::REG_Q {
+        } else if bank_idx == 0x0 && bank_offset == consts::cpu::REG_Q {
             self.banks[bank_idx][bank_offset] = value;
         } else {
             let a = value & 0x7FFF;
@@ -199,7 +199,7 @@ mod agc_ram_tests {
     #[test]
     fn test_read_s16_locations() {
         let mut ram = AgcRam::new();
-        let regs_16bit = [cpu::REG_A, cpu::REG_Q];
+        let regs_16bit = [consts::cpu::REG_A, consts::cpu::REG_Q];
 
         // Testing 16Bit
         for reg_idx in regs_16bit.iter() {
@@ -254,7 +254,7 @@ mod agc_ram_tests {
     #[test]
     fn test_write_s16_locations() {
         let mut ram = AgcRam::new();
-        let regs_16bit = [cpu::REG_A, cpu::REG_Q];
+        let regs_16bit = [consts::cpu::REG_A, consts::cpu::REG_Q];
 
         // Testing 16Bit
         for reg_idx in regs_16bit.iter() {

--- a/ragc-core/src/mem/regs.rs
+++ b/ragc-core/src/mem/regs.rs
@@ -1,5 +1,6 @@
-use crate::cpu;
+use crate::{cpu, consts};
 use crate::mem::AgcMemType;
+
 
 use log::debug;
 
@@ -30,9 +31,9 @@ impl AgcRegs {
         let evalue: u16 = ((self.ebank & 0x7) << 8) as u16;
         let fvalue: u16 = ((self.fbank & 0x1F) << 10) as u16;
         let bvalue: u16 = (evalue >> 8) | fvalue;
-        self.regs[cpu::REG_EB] = evalue;
-        self.regs[cpu::REG_FB] = fvalue;
-        self.regs[cpu::REG_BB] = bvalue;
+        self.regs[consts::cpu::REG_EB] = evalue;
+        self.regs[consts::cpu::REG_FB] = fvalue;
+        self.regs[consts::cpu::REG_BB] = bvalue;
         debug!(
             "Updating Bank Registers: {:x} | {:x} | {:x}",
             evalue, fvalue, bvalue
@@ -43,9 +44,9 @@ impl AgcRegs {
 impl AgcMemType for AgcRegs {
     fn read(&self, _bank_idx: usize, bank_offset: usize) -> u16 {
         match bank_offset {
-            cpu::REG_A | cpu::REG_Q => self.regs[bank_offset],
-            cpu::REG_Z => self.regs[bank_offset] & 0o7777,
-            cpu::REG_ZERO => 0o00000,
+            consts::cpu::REG_A | consts::cpu::REG_Q => self.regs[bank_offset],
+            consts::cpu::REG_Z => self.regs[bank_offset] & 0o7777,
+            consts::cpu::REG_ZERO => 0o00000,
             _ => self.regs[bank_offset] & 0o77777,
         }
     }
@@ -55,7 +56,7 @@ impl AgcMemType for AgcRegs {
             // BB register contains the bank index for both the Erasable memory
             // and ROM Memory window banks. As such, both this and BB register needs to be
             // updated.
-            cpu::REG_BB => {
+            consts::cpu::REG_BB => {
                 self.ebank = (value & 0x7) as usize;
                 self.fbank = ((value & 0x7C00) >> 10) as usize;
                 self.update_bank_registers();
@@ -65,7 +66,7 @@ impl AgcMemType for AgcRegs {
             // EB register contains the bank index for the Erasable memory
             // window bank. As such, both this and BB register needs to be
             // updated.
-            cpu::REG_FB => {
+            consts::cpu::REG_FB => {
                 self.fbank = ((value & 0x7C00) >> 10) as usize;
                 self.update_bank_registers();
                 return;
@@ -74,7 +75,7 @@ impl AgcMemType for AgcRegs {
             // EB register contains the bank index for the Erasable memory
             // window bank. As such, both this and BB register needs to be
             // updated.
-            cpu::REG_EB => {
+            consts::cpu::REG_EB => {
                 self.ebank = ((value & 0x0700) >> 8) as usize;
                 self.update_bank_registers();
                 return;
@@ -83,13 +84,13 @@ impl AgcMemType for AgcRegs {
             // Per the documentation of the Z register, this register is a
             // 12-bit register. As such, no writes or reads should have any
             // values beyond 12 bits.
-            cpu::REG_Z => {
+            consts::cpu::REG_Z => {
                 self.regs[bank_offset] = value & 0o7777;
             }
 
             // Zero register is hardwired to be zero. If there is a write to
             // the zero register, we should atleast warn the user.
-            cpu::REG_ZERO => {
+            consts::cpu::REG_ZERO => {
                 return;
             }
 
@@ -118,8 +119,8 @@ mod regs_unittests {
     fn test_lregister_i15() {
         let mut regs = AgcRegs::new();
         for val in 0o00000..=0o77777 {
-            regs.write(0, crate::cpu::REG_L, val);
-            let retval = regs.read(0, crate::cpu::REG_L);
+            regs.write(0, consts::cpu::REG_L, val);
+            let retval = regs.read(0, consts::cpu::REG_L);
             assert_eq!(
                 retval, val,
                 "Failed in register comparision: e: {:o} | r: {:o}",
@@ -138,8 +139,8 @@ mod regs_unittests {
     fn test_lregister_i16() {
         let mut regs = AgcRegs::new();
         for val in 0o100000..=0o177777 {
-            regs.write(0, crate::cpu::REG_L, val);
-            let retval = regs.read(0, crate::cpu::REG_L);
+            regs.write(0, consts::cpu::REG_L, val);
+            let retval = regs.read(0, consts::cpu::REG_L);
             assert_eq!(
                 retval,
                 val & 0o77777,
@@ -159,7 +160,7 @@ mod regs_unittests {
     ///
     fn test_i16_registers() {
         let mut regs = AgcRegs::new();
-        let target_regs = [crate::cpu::REG_A, crate::cpu::REG_Q];
+        let target_regs = [consts::cpu::REG_A, consts::cpu::REG_Q];
         for reg_idx in target_regs.iter() {
             for val in 0o000000..=0o177777 {
                 regs.write(0, *reg_idx, val);
@@ -192,10 +193,10 @@ mod regs_unittests {
                 let test_bb_value = test_fb_value | (ram_idx & 0o7);
 
                 //println!("{:o} | {:o} | {:o}", test_bb_value, test_eb_value, test_fb_value);
-                regs.write(0, crate::cpu::REG_BB, test_bb_value as u16);
-                assert_eq!(test_bb_value as u16, regs.read(0, crate::cpu::REG_BB), "");
-                assert_eq!(test_eb_value as u16, regs.read(0, crate::cpu::REG_EB), "");
-                assert_eq!(test_fb_value as u16, regs.read(0, crate::cpu::REG_FB), "");
+                regs.write(0, consts::cpu::REG_BB, test_bb_value as u16);
+                assert_eq!(test_bb_value as u16, regs.read(0, consts::cpu::REG_BB), "");
+                assert_eq!(test_eb_value as u16, regs.read(0, consts::cpu::REG_EB), "");
+                assert_eq!(test_fb_value as u16, regs.read(0, consts::cpu::REG_FB), "");
             }
         }
     }
@@ -210,16 +211,16 @@ mod regs_unittests {
     fn test_eb_register() {
         let mut regs = AgcRegs::new();
 
-        regs.write(0, crate::cpu::REG_FB, 0o00000);
+        regs.write(0, consts::cpu::REG_FB, 0o00000);
 
         for ram_idx in 0..consts::RAM_NUM_BANKS {
             let test_eb_value = (0o7 & ram_idx) << 8;
             let test_bb_value = ram_idx & 0o7;
 
             //println!("{:o} | {:o} | {:o}", test_bb_value, test_eb_value, test_fb_value);
-            regs.write(0, crate::cpu::REG_EB, test_eb_value as u16);
-            assert_eq!(test_bb_value as u16, regs.read(0, crate::cpu::REG_BB), "");
-            assert_eq!(test_eb_value as u16, regs.read(0, crate::cpu::REG_EB), "");
+            regs.write(0, consts::cpu::REG_EB, test_eb_value as u16);
+            assert_eq!(test_bb_value as u16, regs.read(0, consts::cpu::REG_BB), "");
+            assert_eq!(test_eb_value as u16, regs.read(0, consts::cpu::REG_EB), "");
         }
     }
 
@@ -233,16 +234,16 @@ mod regs_unittests {
     fn test_fb_register() {
         let mut regs = AgcRegs::new();
 
-        regs.write(0, crate::cpu::REG_FB, 0o00000);
+        regs.write(0, consts::cpu::REG_FB, 0o00000);
 
         for rom_idx in 0..consts::ROM_NUM_BANKS {
             let test_fb_value = ((0o37) & rom_idx) << 10;
             let test_bb_value = test_fb_value;
 
             //println!("{:o} | {:o} | {:o}", test_bb_value, test_eb_value, test_fb_value);
-            regs.write(0, crate::cpu::REG_FB, test_fb_value as u16);
-            assert_eq!(test_bb_value as u16, regs.read(0, crate::cpu::REG_BB), "");
-            assert_eq!(test_fb_value as u16, regs.read(0, crate::cpu::REG_FB), "");
+            regs.write(0, consts::cpu::REG_FB, test_fb_value as u16);
+            assert_eq!(test_bb_value as u16, regs.read(0, consts::cpu::REG_BB), "");
+            assert_eq!(test_fb_value as u16, regs.read(0, consts::cpu::REG_FB), "");
         }
     }
 
@@ -254,8 +255,8 @@ mod regs_unittests {
     fn test_z_register() {
         let mut regs = AgcRegs::new();
         for val in 0o00000..=0o77777 {
-            regs.write(0, crate::cpu::REG_Z, val);
-            let retval = regs.read(0, crate::cpu::REG_Z);
+            regs.write(0, consts::cpu::REG_Z, val);
+            let retval = regs.read(0, consts::cpu::REG_Z);
             assert_eq!(
                 retval,
                 val & 0o07777,

--- a/ragc-core/src/mem/regs.rs
+++ b/ragc-core/src/mem/regs.rs
@@ -1,7 +1,5 @@
-use crate::{cpu, consts};
+use crate::consts;
 use crate::mem::AgcMemType;
-
-
 use log::debug;
 
 #[derive(Clone)]

--- a/ragc-core/src/mem/regs.rs
+++ b/ragc-core/src/mem/regs.rs
@@ -106,6 +106,7 @@ impl AgcMemType for AgcRegs {
 mod regs_unittests {
     use super::AgcMemType;
     use super::AgcRegs;
+    use crate::consts;
 
     #[test]
     ///
@@ -184,9 +185,9 @@ mod regs_unittests {
     fn test_bb_register() {
         let mut regs = AgcRegs::new();
 
-        for ram_idx in 0..crate::mem::ram::RAM_NUM_BANKS {
+        for ram_idx in 0..consts::RAM_NUM_BANKS {
             let test_eb_value = (0o7 & ram_idx) << 8;
-            for rom_idx in 0..crate::mem::rom::ROM_BANKS_NUM {
+            for rom_idx in 0..consts::ROM_NUM_BANKS {
                 let test_fb_value = ((0o37) & rom_idx) << 10;
                 let test_bb_value = test_fb_value | (ram_idx & 0o7);
 
@@ -211,7 +212,7 @@ mod regs_unittests {
 
         regs.write(0, crate::cpu::REG_FB, 0o00000);
 
-        for ram_idx in 0..crate::mem::ram::RAM_NUM_BANKS {
+        for ram_idx in 0..consts::RAM_NUM_BANKS {
             let test_eb_value = (0o7 & ram_idx) << 8;
             let test_bb_value = ram_idx & 0o7;
 
@@ -234,7 +235,7 @@ mod regs_unittests {
 
         regs.write(0, crate::cpu::REG_FB, 0o00000);
 
-        for rom_idx in 0..crate::mem::rom::ROM_BANKS_NUM {
+        for rom_idx in 0..consts::ROM_NUM_BANKS {
             let test_fb_value = ((0o37) & rom_idx) << 10;
             let test_bb_value = test_fb_value;
 

--- a/ragc-core/src/mem/rom.rs
+++ b/ragc-core/src/mem/rom.rs
@@ -1,17 +1,16 @@
 use log::{info, warn};
 
 use crate::mem::AgcMemType;
+use crate::consts;
 use crate::utils::Option as Option;
 
 #[allow(dead_code)]
 const DATA_LINE_NUM_PARTS: usize = 8;
 #[allow(dead_code)]
 const DATA_LINE_PART_LEN: usize = 6;
-pub const ROM_BANKS_NUM: usize = 36;
-pub const ROM_BANK_NUM_WORDS: usize = 1024;
 
 pub struct AgcRom<'a> {
-    program: Option<&'a [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM]>
+    program: Option<&'a [[u16; consts::ROM_BANK_NUM_WORDS]; consts::ROM_NUM_BANKS]>
 }
 
 // ============================================================================
@@ -19,7 +18,7 @@ pub struct AgcRom<'a> {
 // ============================================================================
 impl <'a>AgcMemType for AgcRom<'a> {
     fn read(&self, bank_idx: usize, bank_offset: usize) -> u16 {
-        if bank_idx >= ROM_BANKS_NUM || bank_offset >= ROM_BANK_NUM_WORDS {
+        if bank_idx >= consts::ROM_NUM_BANKS || bank_offset >= consts::ROM_BANK_NUM_WORDS {
             warn!(
                 "Out of bound indexing into AgcRom {} {}",
                 bank_idx, bank_offset
@@ -45,7 +44,7 @@ impl <'a>AgcMemType for AgcRom<'a> {
     }
 
     fn write(&mut self, bank_idx: usize, bank_offset: usize, value: u16) {
-        if bank_idx >= ROM_BANKS_NUM || bank_offset >= ROM_BANK_NUM_WORDS {
+        if bank_idx >= consts::ROM_NUM_BANKS || bank_offset >= consts::ROM_BANK_NUM_WORDS {
             warn!(
                 "Out of bound indexing into AgcRom {} {}",
                 bank_idx, bank_offset
@@ -58,7 +57,7 @@ impl <'a>AgcMemType for AgcRom<'a> {
 }
 
 impl <'a>AgcRom<'a> {
-    pub fn new(program: &'a [[u16; ROM_BANK_NUM_WORDS]; ROM_BANKS_NUM]) -> AgcRom {
+    pub fn new(program: &'a [[u16; consts::ROM_BANK_NUM_WORDS]; consts::ROM_NUM_BANKS]) -> AgcRom {
         AgcRom {
             program: Option::Some(program),
         }

--- a/ragc-core/src/mem/special.rs
+++ b/ragc-core/src/mem/special.rs
@@ -1,30 +1,7 @@
 use crate::mem::AgcMemType;
+use crate::consts::special::*;
 use heapless::spsc::Producer;
 use log::{error, warn};
-
-const SG_CDUX: usize = 0o32;
-const SG_CDUY: usize = 0o33;
-const SG_CDUZ: usize = 0o34;
-const SG_OPTY: usize = 0o35;
-const SG_OPTX: usize = 0o36;
-const SG_PIPAX: usize = 0o37;
-const SG_PIPAY: usize = 0o40;
-const SG_PIPAZ: usize = 0o41;
-const _SG_RCHP: usize = 0o42;
-const _SG_RCHY: usize = 0o43;
-const _SG_RCHR: usize = 0o44;
-const SG_INLINK: usize = 0o45;
-const _SG_RNRAD: usize = 0o46;
-const _SG_GYROCTR: usize = 0o47;
-const SG_CDUXCMD: usize = 0o50;
-const SG_CDUYCMD: usize = 0o51;
-const SG_CDUZCMD: usize = 0o52;
-const _SG_OPTYCMD: usize = 0o53;
-const _SG_OPTXCMD: usize = 0o54;
-const _SG_THRUST: usize = 0o55; // LM only
-const _SG_LEMONM: usize = 0o56; // LM only
-const SG_OUTLINK: usize = 0o57;
-const _SG_ALTM: usize = 0o60; // LM Only
 
 // =============================================================================
 // Public Structures

--- a/ragc-core/src/mem/timer.rs
+++ b/ragc-core/src/mem/timer.rs
@@ -36,13 +36,6 @@ pub enum TimerType {
     TIME6,
 }
 
-pub const MM_TIME2: usize = 0o24;
-pub const MM_TIME1: usize = 0o25;
-pub const MM_TIME3: usize = 0o26;
-pub const MM_TIME4: usize = 0o27;
-pub const MM_TIME5: usize = 0o30;
-pub const MM_TIME6: usize = 0o31;
-
 fn push_unprog_seq(unprog: &mut Deque<AgcUnprogSeq, 8>, seq: AgcUnprogSeq) {
     match unprog.push_back(seq) {
         Err(x) => {
@@ -339,12 +332,12 @@ impl AgcTimers {
 impl AgcMemType for AgcTimers {
     fn read(&self, _bank_idx: usize, bank_offset: usize) -> u16 {
         let res = match bank_offset {
-            MM_TIME2 => ((self.timer1 >> 14) & 0o37777) as u16,
-            MM_TIME1 => (self.timer1 & 0o37777) as u16,
-            MM_TIME3 => self.timer3,
-            MM_TIME4 => self.timer4,
-            MM_TIME5 => self.timer5,
-            MM_TIME6 => self.timer6,
+            consts::timer::MM_TIME2 => ((self.timer1 >> 14) & 0o37777) as u16,
+            consts::timer::MM_TIME1 => (self.timer1 & 0o37777) as u16,
+            consts::timer::MM_TIME3 => self.timer3,
+            consts::timer::MM_TIME4 => self.timer4,
+            consts::timer::MM_TIME5 => self.timer5,
+            consts::timer::MM_TIME6 => self.timer6,
             _ => 0,
         };
         debug!("Reading TIMER: {:o} = {:o}", bank_offset, res);
@@ -357,22 +350,22 @@ impl AgcMemType for AgcTimers {
             value, bank_offset
         );
         match bank_offset {
-            MM_TIME2 => {
+            consts::timer::MM_TIME2 => {
                 self.set_time_value(TimerType::TIME1, value);
             }
-            MM_TIME1 => {
+            consts::timer::MM_TIME1 => {
                 self.set_time_value(TimerType::TIME1, value);
             }
-            MM_TIME3 => {
+            consts::timer::MM_TIME3 => {
                 self.set_time_value(TimerType::TIME3, value);
             }
-            MM_TIME4 => {
+            consts::timer::MM_TIME4 => {
                 self.set_time_value(TimerType::TIME4, value);
             }
-            MM_TIME5 => {
+            consts::timer::MM_TIME5 => {
                 self.set_time_value(TimerType::TIME5, value);
             }
-            MM_TIME6 => {
+            consts::timer::MM_TIME6 => {
                 self.set_time_value(TimerType::TIME6, value);
             }
             _ => {}
@@ -395,11 +388,11 @@ mod timer_modules_tests {
     fn timer_reset_test() {
         let mut timer_mod = timer::AgcTimers::new();
         let timers_addr = [
-            timer::MM_TIME1,
-            timer::MM_TIME3, //timer::MM_TIME2,
-            timer::MM_TIME4,
-            timer::MM_TIME5,
-            timer::MM_TIME6,
+            consts::timer::MM_TIME1,
+            consts::timer::MM_TIME3, //timer::MM_TIME2,
+            consts::timer::MM_TIME4,
+            consts::timer::MM_TIME5,
+            consts::timer::MM_TIME6,
         ];
 
         // Set a known value into the timers so we can compare what it is
@@ -436,32 +429,32 @@ mod timer_modules_tests {
             }
 
             assert_eq!(
-                timers.read(0, super::MM_TIME1),
+                timers.read(0, consts::timer::MM_TIME1),
                 time_idx,
                 "TIME1 did not count properly"
             );
             assert_eq!(
-                timers.read(0, super::MM_TIME2),
+                timers.read(0, consts::timer::MM_TIME2),
                 0,
                 "TIME2 is not the right value"
             );
             assert_eq!(
-                timers.read(0, super::MM_TIME3),
+                timers.read(0, consts::timer::MM_TIME3),
                 time_idx,
                 "TIME3 did not count properly"
             );
             assert_eq!(
-                timers.read(0, super::MM_TIME4),
+                timers.read(0, consts::timer::MM_TIME4),
                 time_idx,
                 "TIME4 did not count properly"
             );
             assert_eq!(
-                timers.read(0, super::MM_TIME5),
+                timers.read(0, consts::timer::MM_TIME5),
                 time_idx,
                 "TIME5 did not count properly"
             );
             assert_eq!(
-                timers.read(0, super::MM_TIME6),
+                timers.read(0, consts::timer::MM_TIME6),
                 0,
                 "TIME6 is not disabled when expected to be"
             );
@@ -481,14 +474,14 @@ mod timer_modules_tests {
         let mut timers = super::AgcTimers::new();
         let mut unprog = heapless::Deque::new();
 
-        timers.write(0, super::MM_TIME1, 0o37777);
+        timers.write(0, consts::timer::MM_TIME1, 0o37777);
         assert_eq!(
-            timers.read(0, super::MM_TIME1),
+            timers.read(0, consts::timer::MM_TIME1),
             0o37777,
             "TIME1 is not being properly set intitially before the test"
         );
         assert_eq!(
-            timers.read(0, super::MM_TIME2),
+            timers.read(0, consts::timer::MM_TIME2),
             0,
             "TIME2 is not being properly set initially before the test"
         );
@@ -498,12 +491,12 @@ mod timer_modules_tests {
         }
 
         assert_eq!(
-            timers.read(0, super::MM_TIME1),
+            timers.read(0, consts::timer::MM_TIME1),
             0o00000,
             "TIME1 did not count properly"
         );
         assert_eq!(
-            timers.read(0, super::MM_TIME2),
+            timers.read(0, consts::timer::MM_TIME2),
             0o00001,
             "TIME2 is not the right value"
         );
@@ -554,7 +547,7 @@ mod timer_modules_tests {
     /// flag is generated because of this.
     ///
     fn test_time3_overflow() {
-        test_time_overflow(super::MM_TIME3, consts::cpu::RUPT_TIME3);
+        test_time_overflow(consts::timer::MM_TIME3, consts::cpu::RUPT_TIME3);
     }
 
     #[test]
@@ -565,7 +558,7 @@ mod timer_modules_tests {
     /// flag is generated because of this.
     ///
     fn test_time4_overflow() {
-        test_time_overflow(super::MM_TIME4, consts::cpu::RUPT_TIME4);
+        test_time_overflow(consts::timer::MM_TIME4, consts::cpu::RUPT_TIME4);
     }
 
     #[test]
@@ -576,7 +569,7 @@ mod timer_modules_tests {
     /// flag is generated because of this.
     ///
     fn test_time5_overflow() {
-        test_time_overflow(super::MM_TIME5, consts::cpu::RUPT_TIME5);
+        test_time_overflow(consts::timer::MM_TIME5, consts::cpu::RUPT_TIME5);
     }
 
     #[test]
@@ -595,20 +588,20 @@ mod timer_modules_tests {
                 timers.pump_mcts(1, &mut unprog);
             }
             assert_eq!(
-                timers.read(0, super::MM_TIME6),
+                timers.read(0, consts::timer::MM_TIME6),
                 0,
                 "TIME6 is not disabled when expected to be"
             );
         }
 
         timers.set_time6_enable(true);
-        timers.write(0, super::MM_TIME6, 0o7);
+        timers.write(0, consts::timer::MM_TIME6, 0o7);
         for time_idx in 1..=5 {
             for _i in 0..54 {
                 timers.pump_mcts(1, &mut unprog);
             }
             assert_eq!(
-                timers.read(0, super::MM_TIME6),
+                timers.read(0, consts::timer::MM_TIME6),
                 0o7 - time_idx,
                 "TIME6 is not disabled when expected to be"
             );
@@ -628,13 +621,13 @@ mod timer_modules_tests {
         let mut unprog = heapless::Deque::new();
 
         timers.set_time6_enable(true);
-        timers.write(0, super::MM_TIME6, 0o1);
+        timers.write(0, consts::timer::MM_TIME6, 0o1);
         let mut interrupt_flags = 0;
         for _i in 0..54 {
             interrupt_flags |= timers.pump_mcts(1, &mut unprog);
         }
         assert_eq!(
-            timers.read(0, super::MM_TIME6),
+            timers.read(0, consts::timer::MM_TIME6),
             0,
             "TIME6 value is not what is expected."
         );
@@ -652,7 +645,7 @@ mod timer_modules_tests {
             "Did not get interrupt"
         );
         assert_eq!(
-            timers.read(0, super::MM_TIME6),
+            timers.read(0, consts::timer::MM_TIME6),
             0,
             "TIME6 value is not what is expected."
         );
@@ -675,7 +668,7 @@ mod timer_modules_tests {
         // Enable the timer and prime it with a given value to test when the
         // timer hits 0.
         timers.set_time6_enable(true);
-        timers.write(0, super::MM_TIME6, 0o77776);
+        timers.write(0, consts::timer::MM_TIME6, 0o77776);
 
         // Pump in 54 MCTs which is equivalent to 1/1600 of a second.
         for _i in 0..54 {
@@ -685,7 +678,7 @@ mod timer_modules_tests {
         // Test that we have properly hit -0 and did not set the interrupt value
         // yet. Also TIME6 is not disabled yet. The next increment should be
         assert_eq!(
-            timers.read(0, super::MM_TIME6),
+            timers.read(0, consts::timer::MM_TIME6),
             0o77777,
             "TIME6 value is not what is expected."
         );
@@ -701,7 +694,7 @@ mod timer_modules_tests {
             "Did not get interrupt"
         );
         assert_eq!(
-            timers.read(0, super::MM_TIME6),
+            timers.read(0, consts::timer::MM_TIME6),
             0o77777,
             "TIME6 value is not what is expected."
         );

--- a/ragc-core/src/mem/timer.rs
+++ b/ragc-core/src/mem/timer.rs
@@ -1,6 +1,7 @@
 use crate::cpu;
 use crate::cpu::AgcUnprogSeq;
 use crate::mem::AgcMemType;
+use crate::consts;
 
 use heapless::Deque;
 
@@ -147,7 +148,7 @@ impl AgcTimers {
                     // If we are hitting the case where we got to zero, disable
                     // the timer and send the interrupt mask.
                     self.time6_enable = false;
-                    interrupt_mask |= 1 << cpu::RUPT_TIME6;
+                    interrupt_mask |= 1 << consts::cpu::RUPT_TIME6;
                 } else {
                     // Otherwise, we do an ABS value decrement of TIME6 register.
                     // Per the documentation.
@@ -198,7 +199,7 @@ impl AgcTimers {
         self.timer4 = (self.timer4 + 1) & 0o77777;
         if self.timer4 == 0o40000 {
             self.timer4 = 0;
-            return 1 << cpu::RUPT_TIME4;
+            return 1 << consts::cpu::RUPT_TIME4;
         }
 
         0
@@ -208,7 +209,7 @@ impl AgcTimers {
         self.timer5 = (self.timer5 + 1) & 0o77777;
         if self.timer5 == 0o40000 {
             self.timer5 = 0;
-            return 1 << cpu::RUPT_TIME5;
+            return 1 << consts::cpu::RUPT_TIME5;
         }
 
         0
@@ -248,7 +249,7 @@ impl AgcTimers {
     pub fn handle_downrupt(&mut self) -> u16 {
         //self.dnrupt_counter += 1;
         //if self.dnrupt_counter % 2 == 0 {
-        return 1 << cpu::RUPT_DOWNRUPT;
+        return 1 << consts::cpu::RUPT_DOWNRUPT;
         //}
         //0
     }
@@ -264,7 +265,7 @@ impl AgcTimers {
         if self.timer3 == 0o40000 {
             self.timer3 = 0;
             debug!("New TIMER3 interrupt!");
-            return 1 << cpu::RUPT_TIME3;
+            return 1 << consts::cpu::RUPT_TIME3;
         }
 
         0
@@ -382,8 +383,8 @@ impl AgcMemType for AgcTimers {
 
 #[cfg(test)]
 mod timer_modules_tests {
-    use crate::mem::timer;
-    use crate::mem::AgcMemType;
+    use crate::mem::{AgcMemType, timer};
+    use crate::consts;
 
     ///
     /// ## Timer Reset Test
@@ -554,7 +555,7 @@ mod timer_modules_tests {
     /// flag is generated because of this.
     ///
     fn test_time3_overflow() {
-        test_time_overflow(super::MM_TIME3, crate::cpu::RUPT_TIME3);
+        test_time_overflow(super::MM_TIME3, consts::cpu::RUPT_TIME3);
     }
 
     #[test]
@@ -565,7 +566,7 @@ mod timer_modules_tests {
     /// flag is generated because of this.
     ///
     fn test_time4_overflow() {
-        test_time_overflow(super::MM_TIME4, crate::cpu::RUPT_TIME4);
+        test_time_overflow(super::MM_TIME4, consts::cpu::RUPT_TIME4);
     }
 
     #[test]
@@ -576,7 +577,7 @@ mod timer_modules_tests {
     /// flag is generated because of this.
     ///
     fn test_time5_overflow() {
-        test_time_overflow(super::MM_TIME5, crate::cpu::RUPT_TIME5);
+        test_time_overflow(super::MM_TIME5, consts::cpu::RUPT_TIME5);
     }
 
     #[test]
@@ -648,7 +649,7 @@ mod timer_modules_tests {
         }
         assert_eq!(
             interrupt_flags,
-            1 << crate::cpu::RUPT_TIME6,
+            1 << consts::cpu::RUPT_TIME6,
             "Did not get interrupt"
         );
         assert_eq!(
@@ -697,7 +698,7 @@ mod timer_modules_tests {
         }
         assert_eq!(
             interrupt_flags,
-            1 << crate::cpu::RUPT_TIME6,
+            1 << consts::cpu::RUPT_TIME6,
             "Did not get interrupt"
         );
         assert_eq!(

--- a/ragc-core/src/mem/timer.rs
+++ b/ragc-core/src/mem/timer.rs
@@ -1,4 +1,3 @@
-use crate::cpu;
 use crate::cpu::AgcUnprogSeq;
 use crate::mem::AgcMemType;
 use crate::consts;

--- a/ragc-vagc/src/downrupt.rs
+++ b/ragc-vagc/src/downrupt.rs
@@ -65,7 +65,7 @@ impl AgcIoPeriph for DownruptPeriph {
     ///
     fn read(&self, channel_idx: usize) -> u16 {
         match channel_idx {
-            ragc_core::mem::io::CHANNEL_CHAN13 => {
+            ragc_core::consts::io::CHANNEL_CHAN13 => {
                 if self.word_order {
                     1 << 6
                 }
@@ -73,12 +73,12 @@ impl AgcIoPeriph for DownruptPeriph {
                     0o00000
                 }
             }
-            ragc_core::mem::io::CHANNEL_CHAN30 |
-            ragc_core::mem::io::CHANNEL_CHAN31 |
-            ragc_core::mem::io::CHANNEL_CHAN32 |
-            ragc_core::mem::io::CHANNEL_CHAN33 |
-            ragc_core::mem::io::CHANNEL_CHAN34 |
-            ragc_core::mem::io::CHANNEL_CHAN35 => { 0o77777 }
+            ragc_core::consts::io::CHANNEL_CHAN30 |
+            ragc_core::consts::io::CHANNEL_CHAN31 |
+            ragc_core::consts::io::CHANNEL_CHAN32 |
+            ragc_core::consts::io::CHANNEL_CHAN33 |
+            ragc_core::consts::io::CHANNEL_CHAN34 |
+            ragc_core::consts::io::CHANNEL_CHAN35 => { 0o77777 }
             _ => { 0o00000 }
         }
     }
@@ -93,7 +93,7 @@ impl AgcIoPeriph for DownruptPeriph {
     ///
     fn write(&mut self, channel_idx: usize, value: u16) {
         match channel_idx {
-            ragc_core::mem::io::CHANNEL_CHAN13 => {
+            ragc_core::consts::io::CHANNEL_CHAN13 => {
                 if value & (1 << 6) != 0o00000 {
                     self.word_order = true;
                 }
@@ -101,11 +101,11 @@ impl AgcIoPeriph for DownruptPeriph {
                     self.word_order = false;
                 }
             },
-            ragc_core::mem::io::CHANNEL_CHAN34 => {
+            ragc_core::consts::io::CHANNEL_CHAN34 => {
                 let packet = generate_yaagc_packet(channel_idx, value);
                 self.tx.send(packet).unwrap();
             }
-            ragc_core::mem::io::CHANNEL_CHAN35 => {
+            ragc_core::consts::io::CHANNEL_CHAN35 => {
                 let packet = generate_yaagc_packet(channel_idx, value);
                 self.tx.send(packet).unwrap();
             }

--- a/ragc-vagc/src/dsky.rs
+++ b/ragc-vagc/src/dsky.rs
@@ -381,15 +381,15 @@ impl DskyDisplay {
 impl ragc_core::mem::periph::AgcIoPeriph for DskyDisplay {
     fn read(&self, channel_idx: usize) -> u16 {
         match channel_idx {
-            ragc_core::mem::io::CHANNEL_MNKEYIN => {
+            ragc_core::consts::io::CHANNEL_MNKEYIN => {
                 self.read_keypress()
             }
-            ragc_core::mem::io::CHANNEL_CHAN30 => 0o77777,
-            ragc_core::mem::io::CHANNEL_CHAN31 => 0o77777,
-            ragc_core::mem::io::CHANNEL_CHAN32 => {
+            ragc_core::consts::io::CHANNEL_CHAN30 => 0o77777,
+            ragc_core::consts::io::CHANNEL_CHAN31 => 0o77777,
+            ragc_core::consts::io::CHANNEL_CHAN32 => {
                 self.read_proceed_flag()
             }
-            ragc_core::mem::io::CHANNEL_CHAN33 => 0o77777,
+            ragc_core::consts::io::CHANNEL_CHAN33 => 0o77777,
             0o163 => self.get_channel_value(channel_idx),
             _ => { 0o00000 }
         }
@@ -397,13 +397,13 @@ impl ragc_core::mem::periph::AgcIoPeriph for DskyDisplay {
 
     fn write(&mut self, channel_idx: usize, value: u16) {
         match channel_idx {
-            ragc_core::mem::io::CHANNEL_DSKY => {
+            ragc_core::consts::io::CHANNEL_DSKY => {
                 self.set_channel_dsky_value(value);
             },
-            ragc_core::mem::io::CHANNEL_DSALMOUT => {
+            ragc_core::consts::io::CHANNEL_DSALMOUT => {
                 self.set_dsalmout_flags(value);
             }
-            ragc_core::mem::io::CHANNEL_CHAN13 => {
+            ragc_core::consts::io::CHANNEL_CHAN13 => {
                 self.set_channel_value(channel_idx, value);
             }
             0o163 => {
@@ -429,7 +429,7 @@ impl ragc_core::mem::periph::AgcIoPeriph for DskyDisplay {
                     }
                 }
             }
-            (1 << ragc_core::cpu::RUPT_KEY1) as u16
+            (1 << ragc_core::consts::cpu::RUPT_KEY1) as u16
         } else {
             0
         }


### PR DESCRIPTION
PR moves most of the `const` fields being used into one location, `consts.rs`. This should allow for external packages to easily use commonly used values (such as register / named memory locations) that want to implement peripherals.