### PR TITLE
Removed Cargo Workspace

### DIFF
--- a/.github/workflows/ragc-build.yml
+++ b/.github/workflows/ragc-build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check ROM files from checkout
         run: ls -al ./ragc-ropes/res
       - name: Build Rust Project (Debug)
-        run: cargo build
+        run: cd ragc && cargo build
 
   run-ragc-tests:
     runs-on: ubuntu-latest
@@ -38,4 +38,4 @@ jobs:
       - name: Check ROM files from checkout
         run: ls -al ./ragc-ropes/res
       - name: Run Test ${{matrix.test_name}}
-        run: cargo test ${{matrix.test_name}}
+        run: cd ragc && cargo test ${{matrix.test_name}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,0 @@
-[workspace]
-
-members = [
-    "ragc-ropes",
-    "ragc-core",
-    "ragc",
-    "ragc-periph"
-]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ is the same as any standard Cargo application / library. To compile `ragc` the
 following commmand is used:
 
 ```rust
+cd ./ragc
 cargo build
 ```
 
@@ -21,6 +22,7 @@ the `--release` flag is needed. This flag instruct cargo to build the project as
 a release build. The following command demonstrates this:
 
 ```rust
+cd ./ragc
 cargo build --release
 ```
 
@@ -31,6 +33,7 @@ prebuilt images provided by the `ragc-ropes` package. To run a prebuilt ROM
 image, the following command demonstrates how to run the RETREAD50 program
 
 ```bash
+cd ./ragc
 cargo run -- retread50
 ```
 
@@ -55,6 +58,7 @@ Addtional flags and options can be used while running `ragc`.
   specify `RUST_LOG` environment variable with the level of logging desired.
   For example:
     ```rust
+    cd ./ragc
     RUST_LOG=info cargo run --release file (binary path)
     ```
 ## Supporting Peripherials


### PR DESCRIPTION
In preps to allow embedded builds within the project (issues identifying which .cargo/config to use). The plan forward is to keep each folder as separate Cargo packages to allow them to be independent.